### PR TITLE
feat: Allow billing_time attribute for subscription creation

### DIFF
--- a/subscription.go
+++ b/subscription.go
@@ -15,11 +15,11 @@ const (
 	Canceled   SubscriptionStatus = "canceled"
 )
 
-type SubscriptionBillingTime string
+type BillingTime string
 
 const (
-	Anniversary SubscriptionBillingTime = "anniversary"
-	Calendar    SubscriptionBillingTime = "calendar"
+	Anniversary BillingTime = "anniversary"
+	Calendar    BillingTime = "calendar"
 )
 
 type SubscriptionRequest struct {
@@ -35,9 +35,9 @@ type SubscriptionParams struct {
 }
 
 type SubscriptionInput struct {
-	CustomerID  string                  `json:"customer_id,omitempty"`
-	PlanCode    string                  `json:"plan_code,omitempty"`
-	BillingTime SubscriptionBillingTime `json:"billing_time,omitempty"`
+	CustomerID  string      `json:"customer_id,omitempty"`
+	PlanCode    string      `json:"plan_code,omitempty"`
+	BillingTime BillingTime `json:"billing_time,omitempty"`
 }
 
 type Subscription struct {
@@ -47,8 +47,8 @@ type Subscription struct {
 
 	PlanCode string `json:"plan_code"`
 
-	Status      SubscriptionStatus      `json:"status"`
-	BillingTime SubscriptionBillingTime `json:"billing_time"`
+	Status      SubscriptionStatus `json:"status"`
+	BillingTime BillingTime        `json:"billing_time"`
 
 	CreatedAt    *time.Time `json:"created_at"`
 	StartedAt    *time.Time `json:"started_at"`

--- a/subscription.go
+++ b/subscription.go
@@ -47,8 +47,9 @@ type Subscription struct {
 
 	PlanCode string `json:"plan_code"`
 
-	Status      SubscriptionStatus `json:"status"`
-	BillingTime BillingTime        `json:"billing_time"`
+	Status           SubscriptionStatus `json:"status"`
+	BillingTime      BillingTime        `json:"billing_time"`
+	SubscriptionDate string             `json:"subscription_date"`
 
 	CreatedAt    *time.Time `json:"created_at"`
 	StartedAt    *time.Time `json:"started_at"`

--- a/subscription.go
+++ b/subscription.go
@@ -15,6 +15,13 @@ const (
 	Canceled   SubscriptionStatus = "canceled"
 )
 
+type SubscriptionBillingTime string
+
+const (
+	Anniversary SubscriptionBillingTime = "anniversary"
+	Calendar    SubscriptionBillingTime = "calendar"
+)
+
 type SubscriptionRequest struct {
 	client *Client
 }
@@ -28,8 +35,9 @@ type SubscriptionParams struct {
 }
 
 type SubscriptionInput struct {
-	CustomerID string `json:"customer_id,omitempty"`
-	PlanCode   string `json:"plan_code,omitempty"`
+	CustomerID  string                  `json:"customer_id,omitempty"`
+	PlanCode    string                  `json:"plan_code,omitempty"`
+	BillingTime SubscriptionBillingTime `json:"billing_time,omitempty"`
 }
 
 type Subscription struct {
@@ -39,7 +47,8 @@ type Subscription struct {
 
 	PlanCode string `json:"plan_code"`
 
-	Status SubscriptionStatus `json:"status"`
+	Status      SubscriptionStatus      `json:"status"`
+	BillingTime SubscriptionBillingTime `json:"billing_time"`
 
 	CreatedAt    *time.Time `json:"created_at"`
 	StartedAt    *time.Time `json:"started_at"`


### PR DESCRIPTION
## Context

We want to add the ability to choose to bill users at subscription date anniversary and not only on a calendar basis.

## Changes

The objective of this pull request is to add the support for `billing_time` attribute for subscription creation

Possible values will be `anniversary` and `calendar`

The changes are :
- Accept the new `billing_time` argument into 'POST /subscriptions'

## Related resources

This PR follows:
- https://github.com/getlago/lago-api/pull/352 to update the subscription data model.
- https://github.com/getlago/lago-api/pull/360 to add a new date service for invoice bounds
- https://github.com/getlago/lago-api/pull/364 to expose billing time into GraphQL
- https://github.com/getlago/lago-api/pull/365 to expose billing time into API