### PR TITLE
feat(charge): Fix edition of charge on plan update

### DIFF
--- a/charge.go
+++ b/charge.go
@@ -9,16 +9,16 @@ import (
 type ChargeModel string
 
 const (
-	Standard   ChargeModel = "standard"
-	Graduated  ChargeModel = "graduated"
-	Package    ChargeModel = "package"
-	Percentage ChargeModel = "percentage"
+	StandardChargeModel   ChargeModel = "standard"
+	GraduatedChargeModel  ChargeModel = "graduated"
+	PackageChargeModel    ChargeModel = "package"
+	PercentageChargeModel ChargeModel = "percentage"
 )
 
 type Charge struct {
-	LagoID               uuid.UUID         `json:"lago_id,omitempty"`
-	LagoBillableMetricID uuid.UUID         `json:"lago_billable_metric_id,omitempty"`
-	ChargeModel          ChargeModel       `json:"charge_model,omitempty"`
-	CreatedAt            time.Time         `json:"created_at,omitempty"`
-	Properties           map[string]string `json:"properties,omitempty"`
+	LagoID               uuid.UUID              `json:"lago_id,omitempty"`
+	LagoBillableMetricID uuid.UUID              `json:"lago_billable_metric_id,omitempty"`
+	ChargeModel          ChargeModel            `json:"charge_model,omitempty"`
+	CreatedAt            time.Time              `json:"created_at,omitempty"`
+	Properties           map[string]interface{} `json:"properties,omitempty"`
 }

--- a/plan.go
+++ b/plan.go
@@ -30,10 +30,11 @@ const (
 )
 
 type PlanChargeInput struct {
-	BillableMetricID uuid.UUID         `json:"billable_metric_id,omitempty"`
-	AmountCurrency   Currency          `json:"amount_currency,omitempty"`
-	ChargeModel      ChargeModel       `json:"charge_model,omitempty"`
-	Properties       map[string]string `json:"properties"`
+	LagoID           *uuid.UUID             `json:"id,omitempty"`
+	BillableMetricID uuid.UUID              `json:"billable_metric_id,omitempty"`
+	AmountCurrency   Currency               `json:"amount_currency,omitempty"`
+	ChargeModel      ChargeModel            `json:"charge_model,omitempty"`
+	Properties       map[string]interface{} `json:"properties"`
 }
 
 type PlanInput struct {


### PR DESCRIPTION
This PR attempt to fix the charge edition when updating a plan. The `LagoID` field was missing.