### PR TITLE
feat(persisted-metrics): Add support for recurring count aggregation

### DIFF
--- a/billable_metric.go
+++ b/billable_metric.go
@@ -14,10 +14,11 @@ type BillableMetricRequest struct {
 type AggregationType string
 
 const (
-	CountAggregation       AggregationType = "count_agg"
-	SumAggregation         AggregationType = "sum_agg"
-	MaxAggregation         AggregationType = "max_agg"
-	UniqueCountAggregation AggregationType = "unique_count_agg"
+	CountAggregation          AggregationType = "count_agg"
+	SumAggregation            AggregationType = "sum_agg"
+	MaxAggregation            AggregationType = "max_agg"
+	UniqueCountAggregation    AggregationType = "unique_count_agg"
+	RecurringCountAggregation AggregationType = "recurring_count_agg"
 )
 
 type BillableMetricParams struct {


### PR DESCRIPTION
## Context

The objective of this feature is to introduce a system of persistent billable metrics that do not resume to 0 at the end of a billing period.

## Description

This PR adds the support for the new `recurring_count_agg` aggregation type