### PR TITLE
fix(subscription): wrong resty Result struct on GetList

### DIFF
--- a/error.go
+++ b/error.go
@@ -20,3 +20,7 @@ type Error struct {
 
 	ErrorDetail ErrorDetail `json:"error_details"`
 }
+
+func (e ErrorCode) Error() string {
+	return string(e)
+}

--- a/subscription.go
+++ b/subscription.go
@@ -129,7 +129,7 @@ func (sr *SubscriptionRequest) GetList(ctx context.Context, subscriptionListInpu
 	clientRequest := &ClientRequest{
 		Path:        "subscriptions",
 		QueryParams: queryParams,
-		Result:      &PlanResult{},
+		Result:      &SubscriptionResult{},
 	}
 
 	result, clientErr := sr.client.Get(ctx, clientRequest)
@@ -137,7 +137,10 @@ func (sr *SubscriptionRequest) GetList(ctx context.Context, subscriptionListInpu
 		return nil, clientErr
 	}
 
-	subscriptionResult := result.(*SubscriptionResult)
+	subscriptionResult, ok := result.(*SubscriptionResult)
+	if !ok {
+		return nil, &Error{Err: ErrorTypeAssert}
+	}
 
 	return subscriptionResult, nil
 }


### PR DESCRIPTION
Wrong copy past on my previous PR, my bad.
Added a check on type assert to avoid panic, had to implem the missing method to satisfy error type interface (it's a bit unusual to have to do this but it's the fastest way without reworking all the error system).