### PR TITLE
feat(invoices): Addapt invoice type to multiple plan

### DIFF
--- a/invoice.go
+++ b/invoice.go
@@ -102,8 +102,8 @@ type Invoice struct {
 	ChargesFromDate string `json:"charges_from_date,omitempty"`
 	IssuingDate     string `json:"issuing_date,omitempty"`
 
-	Customer     *Customer     `json:"customer,omitempty"`
-	Subscription *Subscription `json:"subscription,omitempty"`
+	Customer     *Customer      `json:"customer,omitempty"`
+	Subscription []Subscription `json:"subscriptions,omitempty"`
 
 	Fees    []InvoiceFee    `json:"fees,omitempty"`
 	Credits []InvoiceCredit `json:"credits,omitempty"`


### PR DESCRIPTION
# Context

With the recent introduction of the multiple plan feature, an invoice can now be attached to more than one subscription

# Description

This pull request goals is to update the `Invoice` type to reflect this change