### PR TITLE
Add ExternalID to SubscriptionInput

### DIFF
--- a/subscription.go
+++ b/subscription.go
@@ -42,6 +42,7 @@ type SubscriptionInput struct {
 	ExternalCustomerID string      `json:"external_customer_id,omitempty"`
 	PlanCode           string      `json:"plan_code,omitempty"`
 	BillingTime        BillingTime `json:"billing_time,omitempty"`
+	ExternalID         string      `json:"external_id"`
 }
 
 type SubscriptionListInput struct {


### PR DESCRIPTION
To get the creation of subscriptions to work with Lago's latest updates, the ExternalID needs to be added to the SubscriptionInput struct.