### PR TITLE
fix(subscription): use externalID on Subscription Terminate following API change

### DIFF
--- a/subscription.go
+++ b/subscription.go
@@ -100,9 +100,9 @@ func (sr *SubscriptionRequest) Create(ctx context.Context, subscriptionInput *Su
 	return subscriptionResult.Subscription, nil
 }
 
-func (sr *SubscriptionRequest) Terminate(ctx context.Context, externalCustomerID string) (*Subscription, *Error) {
+func (sr *SubscriptionRequest) Terminate(ctx context.Context, externalID string) (*Subscription, *Error) {
 	subscriptionInput := &SubscriptionInput{
-		ExternalCustomerID: externalCustomerID,
+		ExternalID: externalID,
 	}
 
 	clientRequest := &ClientRequest{


### PR DESCRIPTION
Spotted this change, maybe it still works with external_customer_id but it makes more sense with the external_id and follow the doc.