### PR TITLE
feat(groups): Add group on billable metric

### DIFF
--- a/billable_metric.go
+++ b/billable_metric.go
@@ -27,11 +27,12 @@ type BillableMetricParams struct {
 }
 
 type BillableMetricInput struct {
-	Name            string          `json:"name,omitempty"`
-	Code            string          `json:"code,omitempty"`
-	Description     string          `json:"description,omitempty"`
-	AggregationType AggregationType `json:"aggregation_type,omitempty"`
-	FieldName       string          `json:"field_name"`
+	Name            string                 `json:"name,omitempty"`
+	Code            string                 `json:"code,omitempty"`
+	Description     string                 `json:"description,omitempty"`
+	AggregationType AggregationType        `json:"aggregation_type,omitempty"`
+	FieldName       string                 `json:"field_name"`
+	Group           map[string]interface{} `json:"group,omitempty"`
 }
 
 type BillableMetricListInput struct {


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/32

## Context

We want to be able to price differently billable metrics according to several dimensions (groups).

For example, creating a `storage` pricing based on the `region of the server` and the `cloud provider` used.

## Description

This PR adds `group` on `billable_metric`.