### PR TITLE
feat (subscriptions): add support for subscription date param

### DIFF
--- a/subscription.go
+++ b/subscription.go
@@ -41,6 +41,7 @@ type SubscriptionParams struct {
 type SubscriptionInput struct {
 	ExternalCustomerID string      `json:"external_customer_id,omitempty"`
 	PlanCode           string      `json:"plan_code,omitempty"`
+	SubscriptionDate   string      `json:"subscription_date,omitempty"`
 	BillingTime        BillingTime `json:"billing_time,omitempty"`
 	ExternalID         string      `json:"external_id"`
 }


### PR DESCRIPTION
This PR adds support for `subscription_date` param when creating or updating subscription