### PR TITLE
feat(events): Add ExternalSubscriptionID to event params

### DIFF
--- a/event.go
+++ b/event.go
@@ -11,11 +11,12 @@ type EventParams struct {
 }
 
 type EventInput struct {
-	TransactionID      string            `json:"transaction_id,omitempty"`
-	ExternalCustomerID string            `json:"external_customer_id,omitempty"`
-	Code               string            `json:"code,omitempty"`
-	Timestamp          int64             `json:"timestamp,omitempty"`
-	Properties         map[string]string `json:"properties,omitempty"`
+	TransactionID          string            `json:"transaction_id,omitempty"`
+	ExternalCustomerID     string            `json:"external_customer_id,omitempty"`
+	ExternalSubscriptionID string            `json:"external_subscription_id,omitempty"`
+	Code                   string            `json:"code,omitempty"`
+	Timestamp              int64             `json:"timestamp,omitempty"`
+	Properties             map[string]string `json:"properties,omitempty"`
 }
 
 func (c *Client) Event() *EventRequest {


### PR DESCRIPTION
According to https://doc.getlago.com/docs/api/events/metered-event#arguments `external_subscription_id` should exist in the client.