### PR TITLE
feat(groups): Add group_properties on charge and groups endpoint

### DIFF
--- a/charge.go
+++ b/charge.go
@@ -21,4 +21,10 @@ type Charge struct {
 	ChargeModel          ChargeModel            `json:"charge_model,omitempty"`
 	CreatedAt            time.Time              `json:"created_at,omitempty"`
 	Properties           map[string]interface{} `json:"properties,omitempty"`
+	GroupProperties      []GroupProperties      `json:"group_properties,omitempty"`
+}
+
+type GroupProperties struct {
+	GroupId uuid.UUID              `json:"group_id"`
+	Values  map[string]interface{} `json:"values"`
 }

--- a/group.go
+++ b/group.go
@@ -1,0 +1,64 @@
+package lago
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+type GroupRequest struct {
+	client *Client
+}
+
+type GroupResult struct {
+	Groups []Group  `json:"groups,omitempty"`
+	Meta   Metadata `json:"meta,omitempty"`
+}
+
+type GroupListInput struct {
+	PerPage int    `json:"per_page,omitempty,string"`
+	Page    int    `json:"page,omitempty,string"`
+	Code    string `json:"code,omitempty"`
+}
+
+type Group struct {
+	LagoID uuid.UUID `json:"lago_id,omitempty"`
+	Key    string    `json:"key,omitempty"`
+	Value  string    `json:"value,omitempty"`
+}
+
+func (c *Client) Group() *GroupRequest {
+	return &GroupRequest{
+		client: c,
+	}
+}
+
+func (cr *GroupRequest) GetList(ctx context.Context, groupListInput *GroupListInput) (*GroupResult, *Error) {
+	jsonQueryParams, err := json.Marshal(groupListInput)
+	if err != nil {
+		return nil, &Error{Err: err}
+	}
+
+	queryParams := make(map[string]string)
+	if err = json.Unmarshal(jsonQueryParams, &queryParams); err != nil {
+		return nil, &Error{Err: err}
+	}
+
+	subPath := fmt.Sprintf("%s/%s/%s", "billable_metrics", groupListInput.Code, "groups")
+	clientRequest := &ClientRequest{
+		Path:        subPath,
+		QueryParams: queryParams,
+		Result:      &GroupResult{},
+	}
+
+	result, clientErr := cr.client.Get(ctx, clientRequest)
+	if clientErr != nil {
+		return nil, clientErr
+	}
+
+	groupResult := result.(*GroupResult)
+
+	return groupResult, nil
+}

--- a/plan.go
+++ b/plan.go
@@ -36,6 +36,7 @@ type PlanChargeInput struct {
 	AmountCurrency   Currency               `json:"amount_currency,omitempty"`
 	ChargeModel      ChargeModel            `json:"charge_model,omitempty"`
 	Properties       map[string]interface{} `json:"properties"`
+	GroupProperties  []GroupProperties      `json:"group_properties,omitempty"`
 }
 
 type PlanInput struct {


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/32

## Context

We want to be able to price differently billable metrics according to several dimensions (groups).

For example, creating a `storage` pricing based on the `region of the server` and the `cloud provider` used.

## Description

This PR adds documentation for:
- `group_properties` on `charge` creation
- `GET billables_metrics/:code/groups` endpoint
