### PR TITLE
misc: Move fields to billing configuration

### DIFF
--- a/customer.go
+++ b/customer.go
@@ -45,7 +45,6 @@ type CustomerInput struct {
 	URL                  string                            `json:"url,omitempty"`
 	Currency             Currency                          `json:"currency,omitempty"`
 	BillingConfiguration CustomerBillingConfigurationInput `json:"billing_configuration,omitempty"`
-	VatRate              float32                           `json:"vat_rate,omitempty"`
 }
 
 type CustomerListInput struct {
@@ -57,11 +56,14 @@ type CustomerBillingConfigurationInput struct {
 	PaymentProvider    CustomerPaymentProvider `json:"payment_provider,omitempty"`
 	ProviderCustomerID string                  `json:"provider_customer_id,omitempty"`
 	Sync               bool                    `json:"sync,omitempty"`
+	VatRate            float32                 `json:"vat_rate,omitempty"`
 }
 
 type CustomerBillingConfiguration struct {
 	PaymentProvider    CustomerPaymentProvider `json:"payment_provider,omitempty"`
 	ProviderCustomerID string                  `json:"provider_customer_id,omitempty"`
+	Sync               bool                    `json:"sync,omitempty"`
+	VatRate            float32                 `json:"vat_rate,omitempty"`
 }
 
 type CustomerChargeUsage struct {
@@ -108,7 +110,6 @@ type Customer struct {
 	Phone                string                       `json:"phone,omitempty"`
 	URL                  string                       `json:"url,omitempty"`
 	BillingConfiguration CustomerBillingConfiguration `json:"billing_configuration,omitempty"`
-	VatRate              float32                      `json:"vat_rate,omitempty"`
 	Currency             Currency                     `json:"currency,omitempty"`
 
 	CreatedAt time.Time `json:"created_at,omitempty"`

--- a/organization.go
+++ b/organization.go
@@ -13,22 +13,30 @@ type OrganizationParams struct {
 	Organization *OrganizationInput `json:"organization"`
 }
 
+type OrganizationBillingConfigurationInput struct {
+	InvoiceFooter string  `json:"invoice_footer,omitempty"`
+	VatRate       float32 `json:"vat_rate,omitempty"`
+}
+
+type OrganizationBillingConfiguration struct {
+	InvoiceFooter string  `json:"invoice_footer,omitempty"`
+	VatRate       float32 `json:"vat_rate,omitempty"`
+}
+
 type OrganizationInput struct {
 	Name string `json:"name,omitempty"`
 
-	Email        string `json:"email,omitempty"`
-	AddressLine1 string `json:"address_line_1,omitempty"`
-	AddressLine2 string `json:"address_line_2,omitempty"`
-	City         string `json:"city,omitempty"`
-	Zipcode      string `json:"zipcode,omitempty"`
-	State        string `json:"state,omitempty"`
-	Country      string `json:"country,omitempty"`
-	LegalName    string `json:"legal_name,omitempty"`
-	LegalNumber  string `json:"legal_number,omitempty"`
-
-	InvoiceFooter string  `json:"invoice_footer,omitempty"`
-	WebhookURL    string  `json:"webhook_url,omitempty"`
-	VatRate       float32 `json:"vat_rate,omitempty"`
+	Email                string                                `json:"email,omitempty"`
+	AddressLine1         string                                `json:"address_line_1,omitempty"`
+	AddressLine2         string                                `json:"address_line_2,omitempty"`
+	City                 string                                `json:"city,omitempty"`
+	Zipcode              string                                `json:"zipcode,omitempty"`
+	State                string                                `json:"state,omitempty"`
+	Country              string                                `json:"country,omitempty"`
+	LegalName            string                                `json:"legal_name,omitempty"`
+	LegalNumber          string                                `json:"legal_number,omitempty"`
+	WebhookURL           string                                `json:"webhook_url,omitempty"`
+	BillingConfiguration OrganizationBillingConfigurationInput `json:"billing_configuration,omitempty"`
 }
 
 type OrganizationResult struct {
@@ -38,15 +46,16 @@ type OrganizationResult struct {
 type Organization struct {
 	Name string `json:"name,omitempty"`
 
-	Email        string `json:"email,omitempty"`
-	AddressLine1 string `json:"address_line_1,omitempty"`
-	AddressLine2 string `json:"address_line_2,omitempty"`
-	City         string `json:"city,omitempty"`
-	Zipcode      string `json:"zipcode,omitempty"`
-	State        string `json:"state,omitempty"`
-	Country      string `json:"country,omitempty"`
-	LegalName    string `json:"legal_name,omitempty"`
-	LegalNumber  string `json:"legal_number,omitempty"`
+	Email                string                           `json:"email,omitempty"`
+	AddressLine1         string                           `json:"address_line_1,omitempty"`
+	AddressLine2         string                           `json:"address_line_2,omitempty"`
+	City                 string                           `json:"city,omitempty"`
+	Zipcode              string                           `json:"zipcode,omitempty"`
+	State                string                           `json:"state,omitempty"`
+	Country              string                           `json:"country,omitempty"`
+	LegalName            string                           `json:"legal_name,omitempty"`
+	LegalNumber          string                           `json:"legal_number,omitempty"`
+	BillingConfiguration OrganizationBillingConfiguration `json:"billing_configuration,omitempty"`
 
 	CreatedAt time.Time `json:"created_at,omitempty"`
 }


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/99

## Description

The goal of this PR is to move fields related to Billing or Invoice into `billing_configuration`.

For customer: `vat_rate`.

For organization: `invoice_footer`, `vat_rate`.
