### PR TITLE
feat(grace_period): Rename invoice#status to payment_status

### DIFF
--- a/invoice.go
+++ b/invoice.go
@@ -8,14 +8,14 @@ import (
 	"github.com/google/uuid"
 )
 
-type InvoiceStatus string
+type InvoicePaymentStatus string
 type InvoiceFeeItemType string
 type InvoiceCreditItemType string
 
 const (
-	InvoiceStatusPending   InvoiceStatus = "pending"
-	InvoiceStatusSucceeded InvoiceStatus = "succeeded"
-	InvoiceStatusFailed    InvoiceStatus = "failed"
+	InvoicePaymentStatusPending   InvoicePaymentStatus = "pending"
+	InvoicePaymentStatusSucceeded InvoicePaymentStatus = "succeeded"
+	InvoicePaymentStatusFailed    InvoicePaymentStatus = "failed"
 )
 
 const (
@@ -43,8 +43,8 @@ type InvoiceParams struct {
 }
 
 type InvoiceInput struct {
-	LagoID uuid.UUID     `json:"lago_id,omitempty"`
-	Status InvoiceStatus `json:"status,omitempty"`
+	LagoID        uuid.UUID            `json:"lago_id,omitempty"`
+	PaymentStatus InvoicePaymentStatus `json:"payment_status,omitempty"`
 }
 
 type InvoiceListInput struct {
@@ -90,7 +90,7 @@ type Invoice struct {
 	SequentialID int       `json:"sequential_id,omitempty"`
 	Number       string    `json:"number,omitempty"`
 
-	Status InvoiceStatus `json:"status,omitempty"`
+	PaymentStatus InvoicePaymentStatus `json:"payment_status,omitempty"`
 
 	AmountCents       int      `json:"amount_cents,omitempty"`
 	AmountCurrency    Currency `json:"amount_currency,omitempty"`


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/99

## Context

When a billing period is over, users don’t want to invoice straight away.

They want a defined number of days to:
- Collect delayed events for usage
- Adjust invoice amounts for items

## Description

The goal of this PR is to rename `invoice#status` to `invoice#payment_status`.
`invoice#status` will be used to define if the invoice is `draft` or `finalized`.

**⚠️ This is a breaking change PR, do not merge before Dec. 8th.**
