### PR TITLE
feat(timezones): Update clients to support customer timezones

### DIFF
--- a/coupon.go
+++ b/coupon.go
@@ -61,7 +61,7 @@ type CouponInput struct {
 	AmountCents       int                   `json:"amount_cents,omitempty"`
 	AmountCurrency    Currency              `json:"amount_currency,omitempty"`
 	Expiration        CouponExpiration      `json:"expiration,omitempty"`
-	ExpirationAt      *time.Time            `json:"expiration_date,omitempty"`
+	ExpirationAt      *time.Time            `json:"expiration_at,omitempty"`
 	PercentageRate    float32               `json:"percentage_rate,omitempty"`
 	CouponType        CouponCalculationType `json:"coupon_type,omitempty"`
 	Frequency         CouponFrequency       `json:"frequency,omitempty"`

--- a/coupon.go
+++ b/coupon.go
@@ -61,7 +61,7 @@ type CouponInput struct {
 	AmountCents       int                   `json:"amount_cents,omitempty"`
 	AmountCurrency    Currency              `json:"amount_currency,omitempty"`
 	Expiration        CouponExpiration      `json:"expiration,omitempty"`
-	ExpirationDate    string                `json:"expiration_date,omitempty"`
+	ExpirationAt      *time.Time            `json:"expiration_date,omitempty"`
 	PercentageRate    float32               `json:"percentage_rate,omitempty"`
 	CouponType        CouponCalculationType `json:"coupon_type,omitempty"`
 	Frequency         CouponFrequency       `json:"frequency,omitempty"`

--- a/customer.go
+++ b/customer.go
@@ -45,6 +45,7 @@ type CustomerInput struct {
 	Phone                string                            `json:"phone,omitempty"`
 	URL                  string                            `json:"url,omitempty"`
 	Currency             Currency                          `json:"currency,omitempty"`
+	Timezone             string                            `json:"timezone,omitempty"`
 	BillingConfiguration CustomerBillingConfigurationInput `json:"billing_configuration,omitempty"`
 }
 
@@ -78,9 +79,9 @@ type CustomerChargeUsage struct {
 }
 
 type CustomerUsage struct {
-	FromDate    string `json:"from_date,omitempty"`
-	ToDate      string `json:"to_date,omitempty"`
-	IssuingDate string `json:"issuing_date,omitempty"`
+	FromDatetime time.Time `json:"from_datetime,omitempty"`
+	ToDatetime   time.Time `json:"to_datetime,omitempty"`
+	IssuingDate  string    `json:"issuing_date,omitempty"`
 
 	AmountCents         int      `json:"amount_cents,omitempty"`
 	AmountCurrency      Currency `json:"amount_currency,omitempty"`
@@ -117,6 +118,8 @@ type Customer struct {
 	URL                  string                       `json:"url,omitempty"`
 	BillingConfiguration CustomerBillingConfiguration `json:"billing_configuration,omitempty"`
 	Currency             Currency                     `json:"currency,omitempty"`
+	Timezone             string                       `json:"timezone,omitempty"`
+	ApplicableTimezone   string                       `json:"applicable_timezone,omitempty"`
 
 	CreatedAt time.Time `json:"created_at,omitempty"`
 }

--- a/organization.go
+++ b/organization.go
@@ -26,16 +26,18 @@ type OrganizationBillingConfiguration struct {
 type OrganizationInput struct {
 	Name string `json:"name,omitempty"`
 
-	Email                string                                `json:"email,omitempty"`
-	AddressLine1         string                                `json:"address_line_1,omitempty"`
-	AddressLine2         string                                `json:"address_line_2,omitempty"`
-	City                 string                                `json:"city,omitempty"`
-	Zipcode              string                                `json:"zipcode,omitempty"`
-	State                string                                `json:"state,omitempty"`
-	Country              string                                `json:"country,omitempty"`
-	LegalName            string                                `json:"legal_name,omitempty"`
-	LegalNumber          string                                `json:"legal_number,omitempty"`
-	WebhookURL           string                                `json:"webhook_url,omitempty"`
+	Email        string `json:"email,omitempty"`
+	AddressLine1 string `json:"address_line_1,omitempty"`
+	AddressLine2 string `json:"address_line_2,omitempty"`
+	City         string `json:"city,omitempty"`
+	Zipcode      string `json:"zipcode,omitempty"`
+	State        string `json:"state,omitempty"`
+	Country      string `json:"country,omitempty"`
+	LegalName    string `json:"legal_name,omitempty"`
+	LegalNumber  string `json:"legal_number,omitempty"`
+	WebhookURL   string `json:"webhook_url,omitempty"`
+	Timezone     string `json:"timezone,omitempty"`
+
 	BillingConfiguration OrganizationBillingConfigurationInput `json:"billing_configuration,omitempty"`
 }
 
@@ -55,6 +57,7 @@ type Organization struct {
 	Country              string                           `json:"country,omitempty"`
 	LegalName            string                           `json:"legal_name,omitempty"`
 	LegalNumber          string                           `json:"legal_number,omitempty"`
+	Timezone             string                           `json:"timezone,omitempty"`
 	BillingConfiguration OrganizationBillingConfiguration `json:"billing_configuration,omitempty"`
 
 	CreatedAt time.Time `json:"created_at,omitempty"`

--- a/subscription.go
+++ b/subscription.go
@@ -42,7 +42,7 @@ type SubscriptionParams struct {
 type SubscriptionInput struct {
 	ExternalCustomerID string      `json:"external_customer_id,omitempty"`
 	PlanCode           string      `json:"plan_code,omitempty"`
-	SubscriptionDate   string      `json:"subscription_date,omitempty"`
+	SubscriptionAt     *time.Time  `json:"subscription_at,omitempty"`
 	BillingTime        BillingTime `json:"billing_time,omitempty"`
 	ExternalID         string      `json:"external_id"`
 	Name               string      `json:"name"`
@@ -64,9 +64,9 @@ type Subscription struct {
 
 	Name string `json:"name"`
 
-	Status           SubscriptionStatus `json:"status"`
-	BillingTime      BillingTime        `json:"billing_time"`
-	SubscriptionDate string             `json:"subscription_date"`
+	Status         SubscriptionStatus `json:"status"`
+	BillingTime    BillingTime        `json:"billing_time"`
+	SubscriptionAt *time.Time         `json:"subscription_at"`
 
 	PreviousPlanCode  string `json:"previous_plan_code"`
 	NextPlanCode      string `json:"next_plan_code"`

--- a/wallet.go
+++ b/wallet.go
@@ -29,7 +29,7 @@ type WalletInput struct {
 	Name               string     `json:"name,omitempty"`
 	PaidCredits        string     `json:"paid_credits,omitempty"`
 	GrantedCredits     string     `json:"granted_credits,omitempty"`
-	ExpirationAt       *time.Time `json:"expiration_date,omitempty"`
+	ExpirationAt       *time.Time `json:"expiration_at,omitempty"`
 	ExternalCustomerId string     `json:"external_customer_id,omitempty"`
 }
 

--- a/wallet.go
+++ b/wallet.go
@@ -25,12 +25,12 @@ type WalletParams struct {
 }
 
 type WalletInput struct {
-	RateAmount         string `json:"rate_amount,omitempty"`
-	Name               string `json:"name,omitempty"`
-	PaidCredits        string `json:"paid_credits,omitempty"`
-	GrantedCredits     string `json:"granted_credits,omitempty"`
-	ExpirationDate     string `json:"expiration_date,omitempty"`
-	ExternalCustomerId string `json:"external_customer_id,omitempty"`
+	RateAmount         string     `json:"rate_amount,omitempty"`
+	Name               string     `json:"name,omitempty"`
+	PaidCredits        string     `json:"paid_credits,omitempty"`
+	GrantedCredits     string     `json:"granted_credits,omitempty"`
+	ExpirationAt       *time.Time `json:"expiration_date,omitempty"`
+	ExternalCustomerId string     `json:"external_customer_id,omitempty"`
 }
 
 type WalletListInput struct {


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/61

## Context

It’s impossible to bill a customer following its own timezone.
Lago ingests events, creates subscription boundaries and trigger invoices on a UTC timezone, which is the same for everyone.

This feature adds the possibility to choose the timezone an organization or a customer should be billed in.

## Description

This PR adds:
- Support for timezone at customer level
- Support for timezone at organization level
- Replace `expiration_date` by `expiration_at` on coupons
- Replace `expiration_date` by `expiration_at` on wallets
