### PR TITLE
feat(delete_bm): Update response for billable metric deletion

### DIFF
--- a/billable_metric.go
+++ b/billable_metric.go
@@ -48,14 +48,16 @@ type BillableMetricResult struct {
 }
 
 type BillableMetric struct {
-	LagoID          uuid.UUID              `json:"lago_id"`
-	Name            string                 `json:"name,omitempty"`
-	Code            string                 `json:"code,omitempty"`
-	Description     string                 `json:"description,omitempty"`
-	AggregationType AggregationType        `json:"aggregation_type,omitempty"`
-	FieldName       string                 `json:"field_name"`
-	CreatedAt       time.Time              `json:"created_at,omitempty"`
-	Group           map[string]interface{} `json:"group,omitempty"`
+	LagoID                   uuid.UUID              `json:"lago_id"`
+	Name                     string                 `json:"name,omitempty"`
+	Code                     string                 `json:"code,omitempty"`
+	Description              string                 `json:"description,omitempty"`
+	AggregationType          AggregationType        `json:"aggregation_type,omitempty"`
+	FieldName                string                 `json:"field_name"`
+	CreatedAt                time.Time              `json:"created_at,omitempty"`
+	Group                    map[string]interface{} `json:"group,omitempty"`
+	ActiveSubscriptionsCount int                    `json:"active_subscriptions_count,omitempty"`
+	DraftInvoicesCount       int                    `json:"draft_invoices_count,omitempty"`
 }
 
 func (c *Client) BillableMetric() *BillableMetricRequest {


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/179

## Context

As a user, I want to be able to delete a billable metric that is linked to a subscription in case of a change of pricing (e.g. we no longer charge customers based on the number of API calls).

Once deleted, the corresponding charges will be removed from the plans and from all draft invoices.

Deleted metrics will still be included in past invoices (i.e. finalized invoices).

## Description

The goal of this PR is to add on the billable metric response:
- `activeSubscriptionsCount`
- `draftInvoicesCount`

These fields are used to know the impact of deleting billable metric.