### PR TITLE
feat(delete_customer): Add the destroy customer route

### DIFF
--- a/customer.go
+++ b/customer.go
@@ -198,6 +198,26 @@ func (cr *CustomerRequest) CurrentUsage(ctx context.Context, externalCustomerID 
 	return currentUsageResult.CustomerUsage, nil
 }
 
+func (cr *CustomerRequest) Delete(ctx context.Context, externalCustomerID string) (*Customer, *Error) {
+	subPath := fmt.Sprintf("%s/%s", "customers", externalCustomerID)
+	clientRequest := &ClientRequest{
+		Path:   subPath,
+		Result: &CustomerResult{},
+	}
+
+	result, err := cr.client.Delete(ctx, clientRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	customerResult, ok := result.(*CustomerResult)
+	if !ok {
+		return nil, &ErrorTypeAssert
+	}
+
+	return customerResult.Customer, nil
+}
+
 func (cr *CustomerRequest) Get(ctx context.Context, externalCustomerID string) (*Customer, *Error) {
 	subPath := fmt.Sprintf("%s/%s", "customers", externalCustomerID)
 	clientRequest := &ClientRequest{


### PR DESCRIPTION
## Context

Currently, there is no way to delete objects linked to a subscription. This can be a real limitation during PoCs and onboarding, as users have to ping us to delete customers.

The goal of this feature is to be able to soft-delete a customer linked to an active or terminated subscription.

## Description

This PR adds the new customer destroy route