### PR TITLE
feat(delete_coupon): Ability to destroy an applied coupon

### DIFF
--- a/coupon.go
+++ b/coupon.go
@@ -324,3 +324,23 @@ func (cr *CouponRequest) ApplyToCustomer(ctx context.Context, applyCouponInput *
 
 	return appliedCouponResult.AppliedCoupon, nil
 }
+
+func (acr *AppliedCouponRequest) AppliedCouponDelete(ctx context.Context, externalCustomerId string, couponCode string) (*AppliedCoupon, *Error) {
+	subPath := fmt.Sprintf("%s/%s/%s/%s", "customers", externalCustomerId, "coupons", couponCode)
+	clientRequest := &ClientRequest{
+		Path:   subPath,
+		Result: &AppliedCouponResult{},
+	}
+
+	result, err := acr.client.Delete(ctx, clientRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	appliedCouponResult, ok := result.(*AppliedCouponResult)
+	if !ok {
+		return nil, &ErrorTypeAssert
+	}
+
+	return appliedCouponResult.AppliedCoupon, nil
+}


### PR DESCRIPTION
**Context**
Currently, there is no way to delete objects linked to a subscription. This can be a real limitation during PoCs and onboarding, as users have to ping us to delete customers.

The goal of this feature is to be able to soft-delete an applied coupon.

**Description**
This PR adds the destroy endpoint for applied coupon.