### PR TITLE
fix create/update billable metrics

### DIFF
--- a/billable_metric.go
+++ b/billable_metric.go
@@ -24,7 +24,7 @@ const (
 )
 
 type BillableMetricParams struct {
-	BillableMetricInput *BillableMetricInput
+	BillableMetricInput *BillableMetricInput `json:"billable_metric,omitempty"`
 }
 
 type BillableMetricInput struct {
@@ -117,10 +117,13 @@ func (bmr *BillableMetricRequest) GetList(ctx context.Context, billableMetricLis
 }
 
 func (bmr *BillableMetricRequest) Create(ctx context.Context, billableMetricInput *BillableMetricInput) (*BillableMetric, *Error) {
+
 	clientRequest := &ClientRequest{
 		Path:   "billable_metrics",
 		Result: &BillableMetricResult{},
-		Body:   billableMetricInput,
+		Body: &BillableMetricParams{
+			BillableMetricInput: billableMetricInput,
+		},
 	}
 
 	result, err := bmr.client.Post(ctx, clientRequest)
@@ -141,7 +144,9 @@ func (bmr *BillableMetricRequest) Update(ctx context.Context, billableMetricInpu
 	clientRequest := &ClientRequest{
 		Path:   subPath,
 		Result: &BillableMetricResult{},
-		Body:   billableMetricInput,
+		Body: &BillableMetricParams{
+			BillableMetricInput: billableMetricInput,
+		},
 	}
 
 	result, err := bmr.client.Put(ctx, clientRequest)


### PR DESCRIPTION
This PR fixes creating and updating billable metrics. Per the [docs](https://doc.getlago.com/docs/api/billable_metrics/create-billable-metric), create and update requests for Billable Metrics are to be wrapped with `{"billable_metric": <metric>}`, however the existing client sends `{<metric>}` in the POST body.