### PR TITLE
feat(instant_charge): Add API route to show a fee

### DIFF
--- a/credit_note.go
+++ b/credit_note.go
@@ -53,10 +53,10 @@ type CreditListInput struct {
 }
 
 type CreditNoteItem struct {
-	LagoID         uuid.UUID  `json:"lago_id,omitempty"`
-	AmountCents    int        `json:"amount_cents,omitempty"`
-	AmountCurrency Currency   `json:"amount_currency,omitempty"`
-	Fee            InvoiceFee `json:"fee,omitempty"`
+	LagoID         uuid.UUID `json:"lago_id,omitempty"`
+	AmountCents    int       `json:"amount_cents,omitempty"`
+	AmountCurrency Currency  `json:"amount_currency,omitempty"`
+	Fee            Fee       `json:"fee,omitempty"`
 }
 
 type CreditNote struct {

--- a/fee.go
+++ b/fee.go
@@ -1,0 +1,72 @@
+package lago
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+type FeeItemType string
+
+const (
+	FeeItemSubscription FeeItemType = "subscription"
+	FeeItemCharge       FeeItemType = "charge"
+	FeeItemAddOn        FeeItemType = "add_on"
+)
+
+type FeeRequest struct {
+	client *Client
+}
+
+type FeeResult struct {
+	Fee  *Fee     `json:"fee,omitempty"`
+	Meta Metadata `json:"meta,omitempty"`
+}
+
+type FeeItem struct {
+	Type FeeItemType `json:"type,omitempty"`
+	Code string      `json:"code,omitempty"`
+	Name string      `json:"name,omitempty"`
+}
+
+type Fee struct {
+	LagoID      uuid.UUID `json:"lago_id,omitempty"`
+	LagoGroupID uuid.UUID `json:"lago_group_id,omitempty"`
+
+	AmountCents       int    `json:"amount_cents,omitempty"`
+	AmountCurrency    string `json:"amount_currenty,omitempty"`
+	VatAmountCents    int    `json:"vat_amount_cents,omitempty"`
+	VatAmountCurrency string `json:"vat_amount_currency,omitempty"`
+
+	Units       float32 `json:"units,omitempty"`
+	EventsCount int     `json:"events_count,omitempty"`
+
+	Item FeeItem `json:"item,omitempty"`
+}
+
+func (c *Client) Fee() *FeeRequest {
+	return &FeeRequest{
+		client: c,
+	}
+}
+
+func (fr *FeeRequest) Get(ctx context.Context, feeID string) (*Fee, *Error) {
+	subPath := fmt.Sprintf("%s/%s", "fees", feeID)
+	clientRequest := &ClientRequest{
+		Path:   subPath,
+		Result: &FeeResult{},
+	}
+
+	result, err := fr.client.Get(ctx, clientRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	feeResult, ok := result.(*FeeResult)
+	if !ok {
+		return nil, &ErrorTypeAssert
+	}
+
+	return feeResult.Fee, nil
+}

--- a/invoice.go
+++ b/invoice.go
@@ -10,7 +10,6 @@ import (
 
 type InvoiceStatus string
 type InvoicePaymentStatus string
-type InvoiceFeeItemType string
 type InvoiceCreditItemType string
 
 const (
@@ -22,12 +21,6 @@ const (
 	InvoicePaymentStatusPending   InvoicePaymentStatus = "pending"
 	InvoicePaymentStatusSucceeded InvoicePaymentStatus = "succeeded"
 	InvoicePaymentStatusFailed    InvoicePaymentStatus = "failed"
-)
-
-const (
-	InvoiceFeeItemSubscription InvoiceFeeItemType = "subscription"
-	InvoiceFeeItemCharge       InvoiceFeeItemType = "charge"
-	InvoiceFeeItemAddOn        InvoiceFeeItemType = "add_on"
 )
 
 const (
@@ -59,23 +52,6 @@ type InvoiceListInput struct {
 
 	IssuingDateFrom string `json:"issuing_date_from,omitempty"`
 	IssuingDateTo   string `json:"issuing_date_to,omitempty"`
-}
-
-type InvoiceFeeItem struct {
-	Type InvoiceFeeItemType `json:"type,omitempty"`
-	Code string             `json:"code,omitempty"`
-	Name string             `json:"name,omitempty"`
-}
-
-type InvoiceFee struct {
-	Item InvoiceFeeItem `json:"item,omitempty"`
-
-	AmountCents       int      `json:"amount_cents,omitempty"`
-	AmountCurrency    Currency `json:"amount_currency,omitempty"`
-	VatAmountCents    int      `json:"vat_amount_cents,omitempty"`
-	VatAmountCurrency Currency `json:"vat_amount_currency,omitempty"`
-	Units             float32  `json:"units,omitempty,string"`
-	EventsCount       int      `json:"events_count,omitempty"`
 }
 
 type InvoiceCreditItem struct {
@@ -114,7 +90,7 @@ type Invoice struct {
 	Customer      *Customer      `json:"customer,omitempty"`
 	Subscriptions []Subscription `json:"subscriptions,omitempty"`
 
-	Fees    []InvoiceFee    `json:"fees,omitempty"`
+	Fees    []Fee           `json:"fees,omitempty"`
 	Credits []InvoiceCredit `json:"credits,omitempty"`
 }
 


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/149

## Context

Fintech companies want to deduct fees as transactions occur. They need to charge their customers instantly and report those fees in the invoice issued at the end of the billing period.

Example: 0.5% charge on FX transfers. When the customer makes a transfer of $100, they are immediately charged $0.5 (automatically deducted from their wallet). The corresponding fee is included in the invoice sent to the customer at the end of the billing period.

## Description

This PR adds a new route to retrieve a single fee via the API (`GET /api/v1/fees/:id`)

Related to https://github.com/getlago/lago-api/pull/866