### PR TITLE
feat(instant_charge): Ability to define charge as instant

### DIFF
--- a/charge.go
+++ b/charge.go
@@ -20,6 +20,7 @@ type Charge struct {
 	LagoBillableMetricID uuid.UUID              `json:"lago_billable_metric_id,omitempty"`
 	ChargeModel          ChargeModel            `json:"charge_model,omitempty"`
 	CreatedAt            time.Time              `json:"created_at,omitempty"`
+	Instant              bool                   `json:"instant,omitempty"`
 	Properties           map[string]interface{} `json:"properties,omitempty"`
 	GroupProperties      []GroupProperties      `json:"group_properties,omitempty"`
 }

--- a/plan.go
+++ b/plan.go
@@ -35,6 +35,7 @@ type PlanChargeInput struct {
 	BillableMetricID uuid.UUID              `json:"billable_metric_id,omitempty"`
 	AmountCurrency   Currency               `json:"amount_currency,omitempty"`
 	ChargeModel      ChargeModel            `json:"charge_model,omitempty"`
+	Instant          bool                   `json:"instant,omitempty"`
 	Properties       map[string]interface{} `json:"properties"`
 	GroupProperties  []GroupProperties      `json:"group_properties,omitempty"`
 }


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/149

## Context

Fintech companies want to deduct fees as transactions occur. They need to charge their customers instantly and report those fees in the invoice issued at the end of the billing period.

Example: 0.5% charge on FX transfers. When the customer makes a transfer of $100, they are immediately charged $0.5 (automatically deducted from their wallet). The corresponding fee is included in the invoice sent to the customer at the end of the billing period.

## Description

This PR allows having an instant charge.