### PR TITLE
feat(bm): Expose count of attached plans

### DIFF
--- a/billable_metric.go
+++ b/billable_metric.go
@@ -58,6 +58,7 @@ type BillableMetric struct {
 	Group                    map[string]interface{} `json:"group,omitempty"`
 	ActiveSubscriptionsCount int                    `json:"active_subscriptions_count,omitempty"`
 	DraftInvoicesCount       int                    `json:"draft_invoices_count,omitempty"`
+	PlansCount               int                    `json:"plans_count,omitempty"`
 }
 
 func (c *Client) BillableMetric() *BillableMetricRequest {

--- a/charge.go
+++ b/charge.go
@@ -18,6 +18,7 @@ const (
 type Charge struct {
 	LagoID               uuid.UUID              `json:"lago_id,omitempty"`
 	LagoBillableMetricID uuid.UUID              `json:"lago_billable_metric_id,omitempty"`
+	BillableMetricCode   string                 `json:"billable_metric_code,omitempty"`
 	ChargeModel          ChargeModel            `json:"charge_model,omitempty"`
 	CreatedAt            time.Time              `json:"created_at,omitempty"`
 	Properties           map[string]interface{} `json:"properties,omitempty"`


### PR DESCRIPTION
## Context

Plans edition has some issue if you update some properties of a billable metric, especially if you change groups definition or aggregation type :

"After the billable metric edition, new dimensions are created with new group_id that do not match the ones in the plans already defined"

## Description

This PR exposes a new `plans_count` field in the `BillableMetric` response type to let the API users know if the BM is editable.

Related to https://github.com/getlago/lago-api/pull/914
