### PR TITLE
fix: Addresses field mapping

### DIFF
--- a/customer.go
+++ b/customer.go
@@ -49,8 +49,8 @@ type CustomerInput struct {
 	ExternalID           string                            `json:"external_id,omitempty"`
 	Name                 string                            `json:"name,omitempty"`
 	Email                string                            `json:"email,omitempty"`
-	AddressLine1         string                            `json:"address_line_1,omitempty"`
-	AddressLine2         string                            `json:"address_line_2,omitempty"`
+	AddressLine1         string                            `json:"address_line1,omitempty"`
+	AddressLine2         string                            `json:"address_line2,omitempty"`
 	City                 string                            `json:"city,omitempty"`
 	Zipcode              string                            `json:"zipcode,omitempty"`
 	State                string                            `json:"state,omitempty"`

--- a/organization.go
+++ b/organization.go
@@ -31,8 +31,8 @@ type OrganizationInput struct {
 	Name string `json:"name,omitempty"`
 
 	Email        string `json:"email,omitempty"`
-	AddressLine1 string `json:"address_line_1,omitempty"`
-	AddressLine2 string `json:"address_line_2,omitempty"`
+	AddressLine1 string `json:"address_line1,omitempty"`
+	AddressLine2 string `json:"address_line2,omitempty"`
 	City         string `json:"city,omitempty"`
 	Zipcode      string `json:"zipcode,omitempty"`
 	State        string `json:"state,omitempty"`
@@ -53,8 +53,8 @@ type Organization struct {
 	Name string `json:"name,omitempty"`
 
 	Email                string                           `json:"email,omitempty"`
-	AddressLine1         string                           `json:"address_line_1,omitempty"`
-	AddressLine2         string                           `json:"address_line_2,omitempty"`
+	AddressLine1         string                           `json:"address_line1,omitempty"`
+	AddressLine2         string                           `json:"address_line2,omitempty"`
 	City                 string                           `json:"city,omitempty"`
 	Zipcode              string                           `json:"zipcode,omitempty"`
 	State                string                           `json:"state,omitempty"`


### PR DESCRIPTION
Fixes https://github.com/getlago/lago-go-client/issues/62

Fields mapping for addresses fields was wrong. Mapping was defined with `address_line_X` when json is actually sending `address_lineX`