### PR TITLE
feat(instant_charge): Add event estimate fees route

### DIFF
--- a/event.go
+++ b/event.go
@@ -19,6 +19,17 @@ type EventInput struct {
 	Properties             map[string]string `json:"properties,omitempty"`
 }
 
+type EventEstimateFeesParams struct {
+	Event *EventEstimateFeesInput `json:"event"`
+}
+
+type EventEstimateFeesInput struct {
+	ExternalCustomerID     string            `json:"external_customer_id,omitempty"`
+	ExternalSubscriptionID string            `json:"external_subscription_id,omitempty"`
+	Code                   string            `json:"code,omitempty"`
+	Properties             map[string]string `json:"properties,omitempty"`
+}
+
 func (c *Client) Event() *EventRequest {
 	return &EventRequest{
 		client: c,
@@ -41,4 +52,27 @@ func (er *EventRequest) Create(ctx context.Context, eventInput *EventInput) *Err
 	}
 
 	return nil
+}
+
+func (er *EventRequest) EstimateFees(ctx context.Context, estimateInput EventEstimateFeesInput) (*FeeResult, *Error) {
+	eventEstimateParams := &EventEstimateFeesParams{
+		Event: &estimateInput,
+	}
+
+	clientRequest := &ClientRequest{
+		Path: "events/estimate_fees",
+		Body: eventEstimateParams,
+	}
+
+	result, clientErr := er.client.Post(ctx, clientRequest)
+	if clientErr != nil {
+		return nil, clientErr
+	}
+
+	feeResult, ok := result.(*FeeResult)
+	if !ok {
+		return nil, &ErrorTypeAssert
+	}
+
+	return feeResult, nil
 }

--- a/fee.go
+++ b/fee.go
@@ -21,6 +21,7 @@ type FeeRequest struct {
 
 type FeeResult struct {
 	Fee  *Fee     `json:"fee,omitempty"`
+	Fees []Fee    `json:"fees,omitempty"`
 	Meta Metadata `json:"meta,omitempty"`
 }
 


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/instantly-charge-the-customer-when-an-event-is-processed

## Context

Fintech companies want to deduct fees as transactions occur. They need to charge their customers instantly and report those fees in the invoice issued at the end of the billing period.

Example: 0.5% charge on FX transfers. When the customer makes a transfer of $100, they are immediately charged $0.5 (automatically deducted from their wallet). The corresponding fee is included in the invoice sent to the customer at the end of the billing period.

## Description

This PR adds the new `POST api/v1/events/estimate_fees` route

Related to https://github.com/getlago/lago-api/pull/923
