### PR TITLE
fix: allow using other data types as int/float for property values

### DIFF
--- a/event.go
+++ b/event.go
@@ -11,12 +11,12 @@ type EventParams struct {
 }
 
 type EventInput struct {
-	TransactionID          string            `json:"transaction_id,omitempty"`
-	ExternalCustomerID     string            `json:"external_customer_id,omitempty"`
-	ExternalSubscriptionID string            `json:"external_subscription_id,omitempty"`
-	Code                   string            `json:"code,omitempty"`
-	Timestamp              int64             `json:"timestamp,omitempty"`
-	Properties             map[string]string `json:"properties,omitempty"`
+	TransactionID          string                 `json:"transaction_id,omitempty"`
+	ExternalCustomerID     string                 `json:"external_customer_id,omitempty"`
+	ExternalSubscriptionID string                 `json:"external_subscription_id,omitempty"`
+	Code                   string                 `json:"code,omitempty"`
+	Timestamp              int64                  `json:"timestamp,omitempty"`
+	Properties             map[string]interface{} `json:"properties,omitempty"`
 }
 
 type EventEstimateFeesParams struct {


### PR DESCRIPTION
Currently it's required to use strings as values when sending events but using aggregates with usage based metrics it's required to send them as integer or float otherwise the values are ignored.

CURL example from Lago itself where properties "hours" sent as integer.

```
curl --location --request POST "https://lago.instance.com/api/v1/events" \
  --header "Authorization: Bearer $__YOUR_API_KEY__" \
  --header 'Content-Type: application/json' \
  --data-raw '{
    "event": { 
      "transaction_id": "__UNIQUE_ID__", 
      "external_subscription_id": "__EXTERNAL_SUBSCRIPTION_ID__",
      "external_customer_id": "__EXTERNAL_CUSTOMER_ID__", 
      "code": "fra01.xeon.e1200v6.64", 
      "timestamp": $(date +%s), 
      "properties":  { 
        "hours": 12
      }
    }
  }'
```