### PR TITLE
fix: Sending default values when creating plans to API

### DIFF
--- a/plan.go
+++ b/plan.go
@@ -45,10 +45,10 @@ type PlanInput struct {
 	Code              string            `json:"code,omitempty"`
 	Interval          PlanInterval      `json:"interval,omitempty"`
 	Description       string            `json:"description,omitempty"`
-	AmountCents       int               `json:"amount_cents,omitempty"`
+	AmountCents       int               `json:"amount_cents"`
 	AmountCurrency    Currency          `json:"amount_currency,omitempty"`
-	PayInAdvance      bool              `json:"pay_in_advance,omitempty"`
-	BillChargeMonthly bool              `json:"bill_charge_monthly,omitempty"`
+	PayInAdvance      bool              `json:"pay_in_advance"`
+	BillChargeMonthly bool              `json:"bill_charge_monthly"`
 	Charges           []PlanChargeInput `json:"charges,omitempty"`
 }
 


### PR DESCRIPTION
When using omitempty, the field isn't sent to the API at all when its the golang default value. 

bool -> false
int -> 0

This causes issues on the Lago API since `pay_in_advance` and `amount_cents` are required fields in the json. I think that is a issue on other Input structs as well.