### PR TITLE
feat(min_charge): Ability to specify a minimum amount for a charge

### DIFF
--- a/charge.go
+++ b/charge.go
@@ -22,6 +22,7 @@ type Charge struct {
 	ChargeModel          ChargeModel            `json:"charge_model,omitempty"`
 	CreatedAt            time.Time              `json:"created_at,omitempty"`
 	Instant              bool                   `json:"instant,omitempty"`
+	MinAmountCents       int                    `json:"min_amount_cents,omitempty"`
 	Properties           map[string]interface{} `json:"properties,omitempty"`
 	GroupProperties      []GroupProperties      `json:"group_properties,omitempty"`
 }

--- a/fee.go
+++ b/fee.go
@@ -89,6 +89,7 @@ type Fee struct {
 	LagoGroupID            uuid.UUID `json:"lago_group_id,omitempty"`
 	LagoInvoiceID          uuid.UUID `json:"lago_invoice_id,omitempty"`
 	LagoTrueUpFeeID        uuid.UUID `json:"lago_true_up_fee_id,omitempty"`
+	LagoTrueUpParentFeeID  uuid.UUID `json:"lago_true_up_parent_fee_id,omitempty"`
 	ExternalSubscriptionID string    `json:"external_subscription_id,omitempty"`
 
 	AmountCents         int    `json:"amount_cents,omitempty"`

--- a/fee.go
+++ b/fee.go
@@ -88,6 +88,7 @@ type Fee struct {
 	LagoID                 uuid.UUID `json:"lago_id,omitempty"`
 	LagoGroupID            uuid.UUID `json:"lago_group_id,omitempty"`
 	LagoInvoiceID          uuid.UUID `json:"lago_invoice_id,omitempty"`
+	LagoTrueUpFeeID        uuid.UUID `json:"lago_true_up_fee_id,omitempty"`
 	ExternalSubscriptionID string    `json:"external_subscription_id,omitempty"`
 
 	AmountCents         int    `json:"amount_cents,omitempty"`

--- a/plan.go
+++ b/plan.go
@@ -36,6 +36,7 @@ type PlanChargeInput struct {
 	AmountCurrency   Currency               `json:"amount_currency,omitempty"`
 	ChargeModel      ChargeModel            `json:"charge_model,omitempty"`
 	Instant          bool                   `json:"instant,omitempty"`
+	MinAmountCents   int                    `json:"min_amount_cents,omitempty"`
 	Properties       map[string]interface{} `json:"properties"`
 	GroupProperties  []GroupProperties      `json:"group_properties,omitempty"`
 }


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/define-minimum-fees

## Context

We want to allow users to set spendings minimum on usage-based charges.

## Description

The goal of this PR is to:
- add min_amount_cents to Charge
- add lago_true_up_fee_id to Fee
- add lago_true_up_parent_fee_id to Fee