### PR TITLE
feat(coupon): Add new fields and refactoring for coupons applied befo…

### DIFF
--- a/credit_note.go
+++ b/credit_note.go
@@ -70,18 +70,14 @@ type CreditNote struct {
 	CreditStatus CreditNoteCreditStatus `json:"credit_status,omitempty"`
 	RefundStatus CreditNoteRefundStatus `json:"refund_status,omitempty"`
 
-	TotalAmountCents                  int      `json:"total_amount_cents,omitempty"`
-	TotalAmountCurrency               Currency `json:"total_amount_currency,omitempty"`
-	CreditAmountCents                 int      `json:"credit_amount_cents,omitempty"`
-	CreditAmountCurrency              Currency `json:"credit_amount_currency,omitempty"`
-	BalanceAmountCents                int      `json:"balance_amount_cents,omitempty"`
-	BalanceAmountCurrency             Currency `json:"balance_amount_currency,omitempty"`
-	RefundAmountCents                 int      `json:"refund_amount_cents,omitempty"`
-	RefundAmountCurrency              Currency `json:"refund_amount_currency,omitempty"`
-	VatAmountCents                    int      `json:"vat_amount_cents,omitempty"`
-	VatAmountCurrency                 Currency `json:"vat_amount_currency,omitempty"`
-	SubTotalVatExcludedAmountCents    int      `json:"sub_total_vat_excluded_amount_cents,omitempty"`
-	SubTotalVatExcludedAmountCurrency Currency `json:"sub_total_vat_excluded_amount_currency,omitempty"`
+	Currency                       Currency `json:"currency,omitempty"`
+	TotalAmountCents               int      `json:"total_amount_cents,omitempty"`
+	CreditAmountCents              int      `json:"credit_amount_cents,omitempty"`
+	BalanceAmountCents             int      `json:"balance_amount_cents,omitempty"`
+	RefundAmountCents              int      `json:"refund_amount_cents,omitempty"`
+	VatAmountCents                 int      `json:"vat_amount_cents,omitempty"`
+	SubTotalVatExcludedAmountCents int      `json:"sub_total_vat_excluded_amount_cents,omitempty"`
+	CouponsAdjustementAmountCents  int      `json:"coupons_adjustement_amount_cents,omitempty"`
 
 	FileURL string `json:"file_url,omitempty"`
 
@@ -89,6 +85,14 @@ type CreditNote struct {
 	UpdatedAt time.Time `json:"updated_at,omitempty"`
 
 	Items []CreditNoteItem `json:"items,omitempty"`
+
+	// Deprecated: Will be removed in the future
+	TotalAmountCurrency               Currency `json:"total_amount_currency,omitempty"`
+	CreditAmountCurrency              Currency `json:"credit_amount_currency,omitempty"`
+	BalanceAmountCurrency             Currency `json:"balance_amount_currency,omitempty"`
+	RefundAmountCurrency              Currency `json:"refund_amount_currency,omitempty"`
+	VatAmountCurrency                 Currency `json:"vat_amount_currency,omitempty"`
+	SubTotalVatExcludedAmountCurrency Currency `json:"sub_total_vat_excluded_amount_currency,omitempty"`
 }
 
 type CreditNoteItemInput struct {

--- a/invoice.go
+++ b/invoice.go
@@ -100,6 +100,7 @@ type InvoiceCredit struct {
 	LagoID         uuid.UUID `json:"lago_id,omitempty"`
 	AmountCents    int       `json:"amount_cents,omitempty"`
 	AmountCurrency Currency  `json:"amount_currency,omitempty"`
+	BeforeVAT      bool      `json:"before_vat,omitempty"`
 }
 
 type Invoice struct {


### PR DESCRIPTION
# Update `CreditNote` definition:

## New fields
- `currency`
- `coupons_adjustement_amount_cents`

## Deprecated fields
- `total_amount_currency`
- `credit_amount_currency`
- `balance_amount_currency`
- `refund_amount_currency`
- `vat_amount_currency`
- `sub_total_vat_excluded_amount_currency`

# Update `InvoiceCredit` definition

## New field
- `before_vat`