### PR TITLE
fix GetAppliedCoupon ExtCustomerId input

### DIFF
--- a/coupon.go
+++ b/coupon.go
@@ -110,7 +110,7 @@ type AppliedCouponListInput struct {
 	PerPage            int                 `json:"per_page,omitempty,string"`
 	Page               int                 `json:"page,omitempty,string"`
 	Status             AppliedCouponStatus `json:"status,omitempty,string"`
-	ExternalCustomerID string              `json:"external_customer_id,omitempty,string"`
+	ExternalCustomerID string              `json:"external_customer_id,omitempty"`
 }
 
 type ApplyCouponParams struct {


### PR DESCRIPTION
# What
On the `GetAppliedCoupons` method input the string `ExternalCustomerID` was tagged with `json:"string"` which resulted in a request query like this ` https://api.getlago.com/api/v1/applied_coupons?external_customer_id=%225d9710af-ce0e-42b6-970f-ef2008842c8e%22` where `%22` is included because the string is extra escaped.

Removing the `string` tag fixes this issue