### PR TITLE
Fix ListAppliedCoupons Status filter

### DIFF
--- a/coupon.go
+++ b/coupon.go
@@ -109,7 +109,7 @@ type AppliedCouponResult struct {
 type AppliedCouponListInput struct {
 	PerPage            int                 `json:"per_page,omitempty,string"`
 	Page               int                 `json:"page,omitempty,string"`
-	Status             AppliedCouponStatus `json:"status,omitempty,string"`
+	Status             AppliedCouponStatus `json:"status,omitempty"`
 	ExternalCustomerID string              `json:"external_customer_id,omitempty"`
 }
 


### PR DESCRIPTION
# What

Similar to https://github.com/getlago/lago-go-client/pull/85 also the status query param is currently wrongly constructed to do extra quotation marks `"` which land in the query string url escaped.

By removing the excessive json tag 

```diff
- /applied_coupons?status=%22active%22
// turns into
+ /applied_coupons?status=active
```