### PR TITLE
feat(taxes): Add tax resources

### DIFF
--- a/credit_note.go
+++ b/credit_note.go
@@ -59,6 +59,20 @@ type CreditNoteItem struct {
 	Fee            Fee       `json:"fee,omitempty"`
 }
 
+type CreditNoteAppliedTax struct {
+	LagoId           uuid.UUID `json:"lago_id,omitempty"`
+	LagoCreditNoteId uuid.UUID `json:"lago_credit_note_id,omitempty"`
+	LagoTaxId        uuid.UUID `json:"lago_tax_id,omitempty"`
+	TaxName          string    `json:"tax_name,omitempty"`
+	TaxCode          string    `json:"tax_code,omitempty"`
+	TaxRate          float32   `json:"tax_rate,omitempty,string"`
+	TaxDescription   string    `json:"tax_description,omitempty"`
+	AmountCents      int       `json:"amount_cents,omitempty"`
+	AmountCurrency   Currency  `json:"amount_currency,omitempty"`
+	BaseAmountCents  int       `json:"base_amount_cents,omitempty"`
+	CreatedAt        time.Time `json:"created_at,omitempty"`
+}
+
 type CreditNote struct {
 	LagoID        uuid.UUID        `json:"lago_id,omitempty"`
 	SequentialID  int              `json:"sequential_id,omitempty"`
@@ -70,14 +84,15 @@ type CreditNote struct {
 	CreditStatus CreditNoteCreditStatus `json:"credit_status,omitempty"`
 	RefundStatus CreditNoteRefundStatus `json:"refund_status,omitempty"`
 
-	Currency                       Currency `json:"currency,omitempty"`
-	TotalAmountCents               int      `json:"total_amount_cents,omitempty"`
-	CreditAmountCents              int      `json:"credit_amount_cents,omitempty"`
-	BalanceAmountCents             int      `json:"balance_amount_cents,omitempty"`
-	RefundAmountCents              int      `json:"refund_amount_cents,omitempty"`
-	VatAmountCents                 int      `json:"vat_amount_cents,omitempty"`
-	SubTotalVatExcludedAmountCents int      `json:"sub_total_vat_excluded_amount_cents,omitempty"`
-	CouponsAdjustementAmountCents  int      `json:"coupons_adjustement_amount_cents,omitempty"`
+	Currency                          Currency `json:"currency,omitempty"`
+	TotalAmountCents                  int      `json:"total_amount_cents,omitempty"`
+	CreditAmountCents                 int      `json:"credit_amount_cents,omitempty"`
+	BalanceAmountCents                int      `json:"balance_amount_cents,omitempty"`
+	RefundAmountCents                 int      `json:"refund_amount_cents,omitempty"`
+	TaxesAmountCents                  int      `json:"taxes_amount_cents,omitempty"`
+	TaxesRate                         float32  `json:"taxes_rate,omitempty,string"`
+	SubTotalExcludingTaxesAmountCents int      `json:"sub_total_excluding_taxes_amount_cents,omitempty"`
+	CouponsAdjustementAmountCents     int      `json:"coupons_adjustement_amount_cents,omitempty"`
 
 	FileURL string `json:"file_url,omitempty"`
 
@@ -91,7 +106,9 @@ type CreditNote struct {
 	CreditAmountCurrency              Currency `json:"credit_amount_currency,omitempty"`
 	BalanceAmountCurrency             Currency `json:"balance_amount_currency,omitempty"`
 	RefundAmountCurrency              Currency `json:"refund_amount_currency,omitempty"`
+	VatAmountCents                    int      `json:"vat_amount_cents,omitempty"`
 	VatAmountCurrency                 Currency `json:"vat_amount_currency,omitempty"`
+	SubTotalVatExcludedAmountCents    int      `json:"sub_total_vat_excluded_amount_cents,omitempty"`
 	SubTotalVatExcludedAmountCurrency Currency `json:"sub_total_vat_excluded_amount_currency,omitempty"`
 }
 

--- a/customer.go
+++ b/customer.go
@@ -81,7 +81,6 @@ type CustomerBillingConfigurationInput struct {
 	ProviderCustomerID string                  `json:"provider_customer_id,omitempty"`
 	Sync               bool                    `json:"sync,omitempty"`
 	SyncWithProvider   bool                    `json:"sync_with_provider,omitempty"`
-	VatRate            *float32                `json:"vat_rate"`
 	DocumentLocale     string                  `json:"document_locale,omitempty"`
 }
 
@@ -90,7 +89,6 @@ type CustomerBillingConfiguration struct {
 	PaymentProvider    CustomerPaymentProvider `json:"payment_provider,omitempty"`
 	ProviderCustomerID string                  `json:"provider_customer_id,omitempty"`
 	SyncWithProvider   bool                    `json:"sync_with_provider,omitempty"`
-	VatRate            *float32                `json:"vat_rate"`
 	DocumentLocale     string                  `json:"document_locale,omitempty"`
 }
 
@@ -104,16 +102,13 @@ type CustomerChargeUsage struct {
 }
 
 type CustomerUsage struct {
-	FromDatetime time.Time `json:"from_datetime,omitempty"`
-	ToDatetime   time.Time `json:"to_datetime,omitempty"`
-	IssuingDate  string    `json:"issuing_date,omitempty"`
-
-	AmountCents         int      `json:"amount_cents,omitempty"`
-	AmountCurrency      Currency `json:"amount_currency,omitempty"`
-	TotalAmountCents    int      `json:"total_amount_cents,omitempty"`
-	TotalAmountCurrency Currency `json:"total_amount_currency,omitempty"`
-	VatAmountCents      int      `json:"vat_amount_cents,omitempty"`
-	VatAmountCurrency   Currency `json:"vat_amount_currency,omitempty"`
+	FromDatetime     time.Time `json:"from_datetime,omitempty"`
+	ToDatetime       time.Time `json:"to_datetime,omitempty"`
+	IssuingDate      string    `json:"issuing_date,omitempty"`
+	Currency         Currency  `json:"currency,omitempty"`
+	AmountCents      int       `json:"amount_cents,omitempty"`
+	TotalAmountCents int       `json:"total_amount_cents,omitempty"`
+	TaxesAmountCents int       `json:"taxes_amount_cents,omitempty"`
 
 	ChargesUsage []CustomerChargeUsage `json:"charges_usage,omitempty"`
 }

--- a/fee.go
+++ b/fee.go
@@ -84,6 +84,19 @@ type FeeItem struct {
 	ItemType   FeeItemType `json:"item_type,omitempty"`
 }
 
+type FeeAppliedTax struct {
+	LagoId         uuid.UUID `json:"lago_id,omitempty"`
+	LagoFeeId      uuid.UUID `json:"lago_fee_id,omitempty"`
+	LagoTaxId      uuid.UUID `json:"lago_tax_id,omitempty"`
+	TaxName        string    `json:"tax_name,omitempty"`
+	TaxCode        string    `json:"tax_code,omitempty"`
+	TaxRate        float32   `json:"tax_rate,omitempty,string"`
+	TaxDescription string    `json:"tax_description,omitempty"`
+	AmountCents    int       `json:"amount_cents,omitempty"`
+	AmountCurrency Currency  `json:"amount_currency,omitempty"`
+	CreatedAt      time.Time `json:"created_at,omitempty"`
+}
+
 type Fee struct {
 	LagoID                 uuid.UUID `json:"lago_id,omitempty"`
 	LagoGroupID            uuid.UUID `json:"lago_group_id,omitempty"`
@@ -92,17 +105,17 @@ type Fee struct {
 	LagoTrueUpParentFeeID  uuid.UUID `json:"lago_true_up_parent_fee_id,omitempty"`
 	ExternalSubscriptionID string    `json:"external_subscription_id,omitempty"`
 
-	AmountCents         int    `json:"amount_cents,omitempty"`
-	UnitAmountCents     int    `json:"unit_amount_cents,omitempty"`
-	AmountCurrency      string `json:"amount_currency,omitempty"`
-	VatAmountCents      int    `json:"vat_amount_cents,omitempty"`
-	VatAmountCurrency   string `json:"vat_amount_currency,omitempty"`
-	TotalAmountCents    int    `json:"total_amount_cents,omitempty"`
-	TotalAmountCurrency string `json:"total_amount_currency,omitempty"`
-	PayInAdvance        bool   `json:"pay_in_advance,omitempty"`
-	Invoiceable         bool   `json:"invoiceable,omitempty"`
-	FromDate            string `json:"from_date,omitempty"`
-	ToDate              string `json:"to_date,omitempty"`
+	AmountCents         int     `json:"amount_cents,omitempty"`
+	UnitAmountCents     int     `json:"unit_amount_cents,omitempty"`
+	AmountCurrency      string  `json:"amount_currency,omitempty"`
+	TaxesAmountCents    int     `json:"taxes_amount_cents,omitempty"`
+	TaxesRate           float32 `json:"taxes_rate,omitempty,string"`
+	TotalAmountCents    int     `json:"total_amount_cents,omitempty"`
+	TotalAmountCurrency string  `json:"total_amount_currency,omitempty"`
+	PayInAdvance        bool    `json:"pay_in_advance,omitempty"`
+	Invoiceable         bool    `json:"invoiceable,omitempty"`
+	FromDate            string  `json:"from_date,omitempty"`
+	ToDate              string  `json:"to_date,omitempty"`
 
 	Units       string `json:"units,omitempty"`
 	Description string `json:"description,omitempty"`
@@ -115,7 +128,8 @@ type Fee struct {
 	FailedAt    time.Time `json:"failed_at,omitempty"`
 	RefundedAt  time.Time `json:"refunded_at,omitempty"`
 
-	Item FeeItem `json:"item,omitempty"`
+	Item         FeeItem         `json:"item,omitempty"`
+	AppliedTaxes []FeeAppliedTax `json:"applied_taxes,omitempty"`
 }
 
 func (c *Client) Fee() *FeeRequest {

--- a/invoice.go
+++ b/invoice.go
@@ -120,6 +120,19 @@ type InvoiceCredit struct {
 	BeforeVAT      bool      `json:"before_vat,omitempty"`
 }
 
+type InvoiceAppliedTax struct {
+	LagoId         uuid.UUID `json:"lago_id,omitempty"`
+	LagoInvoiceId  uuid.UUID `json:"lago_invoice_id,omitempty"`
+	LagoTaxId      uuid.UUID `json:"lago_tax_id,omitempty"`
+	TaxName        string    `json:"tax_name,omitempty"`
+	TaxCode        string    `json:"tax_code,omitempty"`
+	TaxRate        float32   `json:"tax_rate,omitempty,string"`
+	TaxDescription string    `json:"tax_description,omitempty"`
+	AmountCents    int       `json:"amount_cents,omitempty"`
+	AmountCurrency Currency  `json:"amount_currency,omitempty"`
+	CreatedAt      time.Time `json:"created_at,omitempty"`
+}
+
 type Invoice struct {
 	LagoID       uuid.UUID `json:"lago_id,omitempty"`
 	SequentialID int       `json:"sequential_id,omitempty"`
@@ -133,14 +146,14 @@ type Invoice struct {
 
 	Currency Currency `json:"currency,omitempty"`
 
-	FeesAmountCents                int `json:"fees_amount_cents,omitempty"`
-	VatAmountCents                 int `json:"vat_amount_cents,omitempty"`
-	CouponsAmountCents             int `json:"coupons_amount_cents,omitempty"`
-	CreditNotesAmountCents         int `json:"credit_notes_amount_cents,omitempty"`
-	SubTotalVatExcludedAmountCents int `json:"sub_total_vat_excluded_amount_cents,omitempty"`
-	SubTotalVatIncludedAmountCents int `json:"sub_total_vat_included_amount_cents,omitempty"`
-	TotalAmountCents               int `json:"total_amount_cents,omitempty"`
-	PrepaidCreditAmountCents       int `json:"prepaid_credit_amount_cents,omitempty"`
+	FeesAmountCents                   int `json:"fees_amount_cents,omitempty"`
+	TaxesAmountCents                  int `json:"taxes_amount_cents,omitempty"`
+	CouponsAmountCents                int `json:"coupons_amount_cents,omitempty"`
+	CreditNotesAmountCents            int `json:"credit_notes_amount_cents,omitempty"`
+	SubTotalExcludingTaxesAmountCents int `json:"sub_total_excluding_taxes_amount_cents,omitempty"`
+	SubTotalIncludingTaxesAmountCents int `json:"sub_total_including_taxes_amount_cents,omitempty"`
+	TotalAmountCents                  int `json:"total_amount_cents,omitempty"`
+	PrepaidCreditAmountCents          int `json:"prepaid_credit_amount_cents,omitempty"`
 
 	FileURL       string                    `json:"file_url,omitempty"`
 	Metadata      []InvoiceMetadataResponse `json:"metadata,omitempty"`
@@ -149,17 +162,21 @@ type Invoice struct {
 	Customer      *Customer      `json:"customer,omitempty"`
 	Subscriptions []Subscription `json:"subscriptions,omitempty"`
 
-	Fees    []Fee           `json:"fees,omitempty"`
-	Credits []InvoiceCredit `json:"credits,omitempty"`
+	Fees         []Fee               `json:"fees,omitempty"`
+	Credits      []InvoiceCredit     `json:"credits,omitempty"`
+	AppliedTaxes []InvoiceAppliedTax `json:"applied_taxes,omitempty"`
 
 	// Deprecated: Will be removed in the future
-	Legacy               bool     `json:"legacy,omitempty"`
-	AmountCurrency       Currency `json:"amount_currency,omitempty"`
-	AmountCents          int      `json:"amount_cents,omitempty"`
-	CreditAmountCents    int      `json:"credit_amount_cents,omitempty"`
-	CreditAmountCurrency Currency `json:"credit_amount_currency,omitempty"`
-	TotalAmountCurrency  Currency `json:"total_amount_currency,omitempty"`
-	VatAmountCurrency    Currency `json:"vat_amount_currency,omitempty"`
+	Legacy                         bool     `json:"legacy,omitempty"`
+	AmountCurrency                 Currency `json:"amount_currency,omitempty"`
+	AmountCents                    int      `json:"amount_cents,omitempty"`
+	CreditAmountCents              int      `json:"credit_amount_cents,omitempty"`
+	CreditAmountCurrency           Currency `json:"credit_amount_currency,omitempty"`
+	TotalAmountCurrency            Currency `json:"total_amount_currency,omitempty"`
+	VatAmountCents                 int      `json:"vat_amount_cents,omitempty"`
+	VatAmountCurrency              Currency `json:"vat_amount_currency,omitempty"`
+	SubTotalVatExcludedAmountCents int      `json:"sub_total_vat_excluded_amount_cents,omitempty"`
+	SubTotalVatIncludedAmountCents int      `json:"sub_total_vat_included_amount_cents,omitempty"`
 }
 
 func (c *Client) Invoice() *InvoiceRequest {

--- a/organization.go
+++ b/organization.go
@@ -30,19 +30,19 @@ type OrganizationBillingConfiguration struct {
 type OrganizationInput struct {
 	Name string `json:"name,omitempty"`
 
-	Email                            string   `json:"email,omitempty"`
-	AddressLine1                     string   `json:"address_line1,omitempty"`
-	AddressLine2                     string   `json:"address_line2,omitempty"`
-	City                             string   `json:"city,omitempty"`
-	Zipcode                          string   `json:"zipcode,omitempty"`
-	State                            string   `json:"state,omitempty"`
-	Country                          string   `json:"country,omitempty"`
-	LegalName                        string   `json:"legal_name,omitempty"`
-	LegalNumber                      string   `json:"legal_number,omitempty"`
-	TaxIdentificationNumber          string   `json:"tax_identification_number,omitempty"`
-	WebhookURL                       string   `json:"webhook_url,omitempty"`
-	Timezone                         string   `json:"timezone,omitempty"`
-	EmailSettings                    []string `json:"email_settings,omitempty"`
+	Email                   string   `json:"email,omitempty"`
+	AddressLine1            string   `json:"address_line1,omitempty"`
+	AddressLine2            string   `json:"address_line2,omitempty"`
+	City                    string   `json:"city,omitempty"`
+	Zipcode                 string   `json:"zipcode,omitempty"`
+	State                   string   `json:"state,omitempty"`
+	Country                 string   `json:"country,omitempty"`
+	LegalName               string   `json:"legal_name,omitempty"`
+	LegalNumber             string   `json:"legal_number,omitempty"`
+	TaxIdentificationNumber string   `json:"tax_identification_number,omitempty"`
+	WebhookURL              string   `json:"webhook_url,omitempty"`
+	Timezone                string   `json:"timezone,omitempty"`
+	EmailSettings           []string `json:"email_settings,omitempty"`
 
 	BillingConfiguration OrganizationBillingConfigurationInput `json:"billing_configuration,omitempty"`
 }
@@ -54,20 +54,20 @@ type OrganizationResult struct {
 type Organization struct {
 	Name string `json:"name,omitempty"`
 
-	Email                            string                           `json:"email,omitempty"`
-	AddressLine1                     string                           `json:"address_line1,omitempty"`
-	AddressLine2                     string                           `json:"address_line2,omitempty"`
-	City                             string                           `json:"city,omitempty"`
-	Zipcode                          string                           `json:"zipcode,omitempty"`
-	State                            string                           `json:"state,omitempty"`
-	Country                          string                           `json:"country,omitempty"`
-	LegalName                        string                           `json:"legal_name,omitempty"`
-	LegalNumber                      string                           `json:"legal_number,omitempty"`
-	TaxIdentificationNumber          string                           `json:"tax_identification_number,omitempty"`
-	Timezone                         string                           `json:"timezone,omitempty"`
-	EmailSettings                    []string                         `json:"email_settings,omitempty"`
+	Email                   string   `json:"email,omitempty"`
+	AddressLine1            string   `json:"address_line1,omitempty"`
+	AddressLine2            string   `json:"address_line2,omitempty"`
+	City                    string   `json:"city,omitempty"`
+	Zipcode                 string   `json:"zipcode,omitempty"`
+	State                   string   `json:"state,omitempty"`
+	Country                 string   `json:"country,omitempty"`
+	LegalName               string   `json:"legal_name,omitempty"`
+	LegalNumber             string   `json:"legal_number,omitempty"`
+	TaxIdentificationNumber string   `json:"tax_identification_number,omitempty"`
+	Timezone                string   `json:"timezone,omitempty"`
+	EmailSettings           []string `json:"email_settings,omitempty"`
 
-	BillingConfiguration             OrganizationBillingConfiguration `json:"billing_configuration,omitempty"`
+	BillingConfiguration OrganizationBillingConfiguration `json:"billing_configuration,omitempty"`
 
 	Taxes []Tax `json:"taxes,omitempty"`
 

--- a/organization.go
+++ b/organization.go
@@ -14,17 +14,15 @@ type OrganizationParams struct {
 }
 
 type OrganizationBillingConfigurationInput struct {
-	InvoiceGracePeriod int     `json:"invoice_grace_period,omitempty"`
-	InvoiceFooter      string  `json:"invoice_footer,omitempty"`
-	VatRate            float32 `json:"vat_rate,omitempty"`
-	DocumentLocale     string  `json:"document_locale,omitempty"`
+	InvoiceGracePeriod int    `json:"invoice_grace_period,omitempty"`
+	InvoiceFooter      string `json:"invoice_footer,omitempty"`
+	DocumentLocale     string `json:"document_locale,omitempty"`
 }
 
 type OrganizationBillingConfiguration struct {
-	InvoiceGracePeriod int     `json:"invoice_grace_period,omitempty"`
-	InvoiceFooter      string  `json:"invoice_footer,omitempty"`
-	VatRate            float32 `json:"vat_rate,omitempty"`
-	DocumentLocale     string  `json:"document_locale,omitempty"`
+	InvoiceGracePeriod int    `json:"invoice_grace_period,omitempty"`
+	InvoiceFooter      string `json:"invoice_footer,omitempty"`
+	DocumentLocale     string `json:"document_locale,omitempty"`
 }
 
 type OrganizationInput struct {

--- a/tax.go
+++ b/tax.go
@@ -18,10 +18,10 @@ type TaxParams struct {
 }
 
 type TaxInput struct {
-	Name             string  `json:"name,omitempty"`
-	Code             string  `json:"code,omitempty"`
-	Rate             float32 `json:"rate,omitempty"`
-	Description      string  `json:"description,omitempty"`
+	Name                  string  `json:"name,omitempty"`
+	Code                  string  `json:"code,omitempty"`
+	Rate                  float32 `json:"rate,omitempty"`
+	Description           string  `json:"description,omitempty"`
 	AppliedToOrganization bool    `json:"applied_to_organization,omitempty"`
 }
 


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

Currently, tax can be set individually either on the customer or the organization level. However, it’s not possible to define a global tax tag that can be reusable everywhere.

## Description

The goal of this PR is to add:
- The Tax object
- The relation between taxes and organization
- The relation between taxes and customers
- The relation between taxes and invoices
- The relation between taxes and fees
- The relation between taxes and credit notes