### PR TITLE
fix(tax): Tax rates are exposed as number not as string

### DIFF
--- a/credit_note.go
+++ b/credit_note.go
@@ -65,7 +65,7 @@ type CreditNoteAppliedTax struct {
 	LagoTaxId        uuid.UUID `json:"lago_tax_id,omitempty"`
 	TaxName          string    `json:"tax_name,omitempty"`
 	TaxCode          string    `json:"tax_code,omitempty"`
-	TaxRate          float32   `json:"tax_rate,omitempty,string"`
+	TaxRate          float32   `json:"tax_rate,omitempty"`
 	TaxDescription   string    `json:"tax_description,omitempty"`
 	AmountCents      int       `json:"amount_cents,omitempty"`
 	AmountCurrency   Currency  `json:"amount_currency,omitempty"`
@@ -90,7 +90,7 @@ type CreditNote struct {
 	BalanceAmountCents                int      `json:"balance_amount_cents,omitempty"`
 	RefundAmountCents                 int      `json:"refund_amount_cents,omitempty"`
 	TaxesAmountCents                  int      `json:"taxes_amount_cents,omitempty"`
-	TaxesRate                         float32  `json:"taxes_rate,omitempty,string"`
+	TaxesRate                         float32  `json:"taxes_rate,omitempty"`
 	SubTotalExcludingTaxesAmountCents int      `json:"sub_total_excluding_taxes_amount_cents,omitempty"`
 	CouponsAdjustementAmountCents     int      `json:"coupons_adjustement_amount_cents,omitempty"`
 

--- a/fee.go
+++ b/fee.go
@@ -90,7 +90,7 @@ type FeeAppliedTax struct {
 	LagoTaxId      uuid.UUID `json:"lago_tax_id,omitempty"`
 	TaxName        string    `json:"tax_name,omitempty"`
 	TaxCode        string    `json:"tax_code,omitempty"`
-	TaxRate        float32   `json:"tax_rate,omitempty,string"`
+	TaxRate        float32   `json:"tax_rate,omitempty"`
 	TaxDescription string    `json:"tax_description,omitempty"`
 	AmountCents    int       `json:"amount_cents,omitempty"`
 	AmountCurrency Currency  `json:"amount_currency,omitempty"`
@@ -109,7 +109,7 @@ type Fee struct {
 	UnitAmountCents     int     `json:"unit_amount_cents,omitempty"`
 	AmountCurrency      string  `json:"amount_currency,omitempty"`
 	TaxesAmountCents    int     `json:"taxes_amount_cents,omitempty"`
-	TaxesRate           float32 `json:"taxes_rate,omitempty,string"`
+	TaxesRate           float32 `json:"taxes_rate,omitempty"`
 	TotalAmountCents    int     `json:"total_amount_cents,omitempty"`
 	TotalAmountCurrency string  `json:"total_amount_currency,omitempty"`
 	PayInAdvance        bool    `json:"pay_in_advance,omitempty"`

--- a/invoice.go
+++ b/invoice.go
@@ -126,7 +126,7 @@ type InvoiceAppliedTax struct {
 	LagoTaxId      uuid.UUID `json:"lago_tax_id,omitempty"`
 	TaxName        string    `json:"tax_name,omitempty"`
 	TaxCode        string    `json:"tax_code,omitempty"`
-	TaxRate        float32   `json:"tax_rate,omitempty,string"`
+	TaxRate        float32   `json:"tax_rate,omitempty"`
 	TaxDescription string    `json:"tax_description,omitempty"`
 	AmountCents    int       `json:"amount_cents,omitempty"`
 	AmountCurrency Currency  `json:"amount_currency,omitempty"`


### PR DESCRIPTION
Today, all tax rates are exposed as `float` in Lago API but the current openapi file define them as `string`. 

The current PR fixes it by removing the `string` fields mapping.