### PR TITLE
fix: API error Unmarshaling

### DIFF
--- a/error.go
+++ b/error.go
@@ -15,20 +15,17 @@ const (
 var ErrorTypeAssert = Error{
 	Err:            errors.New("type assertion failed"),
 	HTTPStatusCode: http.StatusUnprocessableEntity,
-	Msg:            "type assertion failed",
-}
-
-type ErrorDetail struct {
-	ErrorCode []ErrorCode `json:"code,omitempty"`
+	Message:        "Type assertion failed",
 }
 
 type Error struct {
 	Err error `json:"-"`
 
 	HTTPStatusCode int    `json:"status"`
-	Msg            string `json:"message"`
+	Message        string `json:"error"`
+	ErrorCode      string `json:"code"`
 
-	ErrorDetail ErrorDetail `json:"error_details"`
+	ErrorDetail map[string][]string `json:"error_details,omitempty"`
 }
 
 func (e ErrorCode) Error() string {

--- a/webhook.go
+++ b/webhook.go
@@ -38,7 +38,7 @@ func (wr *WebhookRequest) GetPublicKey(ctx context.Context) (*rsa.PublicKey, *Er
 		return nil, &Error{
 			Err:            errors.New("response is not a string"),
 			HTTPStatusCode: http.StatusInternalServerError,
-			Msg:            "response is not a string",
+			Message:        "response is not a string",
 		}
 	}
 
@@ -48,7 +48,7 @@ func (wr *WebhookRequest) GetPublicKey(ctx context.Context) (*rsa.PublicKey, *Er
 		return nil, &Error{
 			Err:            decodeErr,
 			HTTPStatusCode: http.StatusInternalServerError,
-			Msg:            "cannot decode the key",
+			Message:        "cannot decode the key",
 		}
 	}
 
@@ -58,7 +58,7 @@ func (wr *WebhookRequest) GetPublicKey(ctx context.Context) (*rsa.PublicKey, *Er
 		return nil, &Error{
 			Err:            errors.New("Failed to decode PEM block containing public key"),
 			HTTPStatusCode: http.StatusInternalServerError,
-			Msg:            "Failed to decode PEM block containing public key",
+			Message:        "Failed to decode PEM block containing public key",
 		}
 	}
 
@@ -68,7 +68,7 @@ func (wr *WebhookRequest) GetPublicKey(ctx context.Context) (*rsa.PublicKey, *Er
 		return nil, &Error{
 			Err:            parseErr,
 			HTTPStatusCode: http.StatusInternalServerError,
-			Msg:            "Failed to to parse the public key",
+			Message:        "Failed to to parse the public key",
 		}
 	}
 
@@ -77,7 +77,7 @@ func (wr *WebhookRequest) GetPublicKey(ctx context.Context) (*rsa.PublicKey, *Er
 		return nil, &Error{
 			Err:            errors.New("Unexpected type of public key"),
 			HTTPStatusCode: http.StatusInternalServerError,
-			Msg:            "Unexpected type of public key",
+			Message:        "Unexpected type of public key",
 		}
 	}
 
@@ -100,7 +100,7 @@ func (wr *WebhookRequest) parseSignature(ctx context.Context, signature string) 
 		return nil, &Error{
 			Err:            parseErr,
 			HTTPStatusCode: http.StatusInternalServerError,
-			Msg:            "cannot parse token",
+			Message:        "cannot parse token",
 		}
 	}
 
@@ -122,7 +122,7 @@ func (wr *WebhookRequest) ValidateBody(ctx context.Context, signature string, bo
 			return false, &Error{
 				Err:            errors.New("error casting claims"),
 				HTTPStatusCode: http.StatusInternalServerError,
-				Msg:            "cannot parse token",
+				Message:        "cannot parse token",
 			}
 		}
 


### PR DESCRIPTION
## Context

Current Error struct does not match format of the API sent by the API

The API format is:

```json
{
  "status": 422, 
  "error": "Unprocessable Entity",
  "code": "validation_errors", 
  "error_details": {
    "code": ["value_already_exist"]
  }
}
```

while the current implementation is expecting:

```json
{
  "status": 422, 
  "message": "Unprocessable Entity",
  "error_details": ["value_already_exist"]
}
```

## Description

This PR updates the struct tags to ensure error received from the API are correctly parsed