### PR TITLE
fix: accept 0% as tax rate

### DIFF
--- a/tax.go
+++ b/tax.go
@@ -42,7 +42,7 @@ type Tax struct {
 	LagoID                uuid.UUID `json:"lago_id,omitempty"`
 	Name                  string    `json:"name,omitempty"`
 	Code                  string    `json:"code,omitempty"`
-	Rate                  float32   `json:"rate,omitempty"`
+	Rate                  float32   `json:"rate"`
 	Description           string    `json:"description,omitempty"`
 	CustomersCount        int       `json:"customers_count,omitempty"`
 	PlansCount            int       `json:"plans_count,omitempty"`


### PR DESCRIPTION
This is to make it possible to set 0% tax rate while creating a tax 

to fix https://github.com/getlago/lago-go-client/issues/119