### PR TITLE
feat(add_on): Remove routes for applied add on creation

### DIFF
--- a/add_on.go
+++ b/add_on.go
@@ -53,34 +53,6 @@ type AddOn struct {
 	CreatedAt time.Time `json:"created_at,omitempty"`
 }
 
-type AppliedAddOnResult struct {
-	AppliedAddOn *AppliedAddOn `json:"applied_add_on,omitempty"`
-}
-
-type ApplyAddOnParams struct {
-	AppliedAddOn *ApplyAddOnInput `json:"applied_add_on"`
-}
-
-type ApplyAddOnInput struct {
-	ExternalCustomerID string   `json:"external_customer_id,omitempty"`
-	AddOnCode          string   `json:"add_on_code,omitempty"`
-	AmountCents        int      `json:"amount_cents,omitempty"`
-	AmountCurrency     Currency `json:"amount_currency,omitempty"`
-}
-
-type AppliedAddOn struct {
-	LagoID             uuid.UUID `json:"lago_id,omitempty"`
-	LagoAddOnID        uuid.UUID `json:"lago_add_on_id,omitempty"`
-	LagoCustomerID     uuid.UUID `json:"lago_customer_id,omitempty"`
-	ExternalCustomerID string    `json:"external_customer_id,omitempty"`
-
-	AddOnCode      string   `json:"add_on_code,omitempty"`
-	AmountCents    int      `json:"amount_cents,omitempty"`
-	AmountCurrency Currency `json:"amount_currency,omitempty"`
-
-	CreatedAt time.Time `json:"created_at,omitempty"`
-}
-
 func (c *Client) AddOn() *AddOnRequest {
 	return &AddOnRequest{
 		client: c,
@@ -205,28 +177,4 @@ func (adr *AddOnRequest) Delete(ctx context.Context, addOnCode string) (*AddOn, 
 	}
 
 	return addOnResult.AddOn, nil
-}
-
-func (adr *AddOnRequest) ApplyToCustomer(ctx context.Context, applyAddOnInput *ApplyAddOnInput) (*AppliedAddOn, *Error) {
-	applyAddOnParams := &ApplyAddOnParams{
-		AppliedAddOn: applyAddOnInput,
-	}
-
-	clientRequest := &ClientRequest{
-		Path:   "applied_add_ons",
-		Result: &AppliedAddOnResult{},
-		Body:   applyAddOnParams,
-	}
-
-	result, err := adr.client.Post(ctx, clientRequest)
-	if err != nil {
-		return nil, err
-	}
-
-	appliedAddOnResult, ok := result.(*AppliedAddOnResult)
-	if !ok {
-		return nil, &ErrorTypeAssert
-	}
-
-	return appliedAddOnResult.AppliedAddOn, nil
 }


### PR DESCRIPTION
## Context

Applied add on have been deprecated since it has been replaced by the invoice creation route.

Related to https://github.com/getlago/lago-api/pull/1282

## Description

This PR removes the routes related to the applied add-ons
