### PR TITLE
feat(weighted-sum): Add weighted sum fields to billable metric

### DIFF
--- a/billable_metric.go
+++ b/billable_metric.go
@@ -21,6 +21,13 @@ const (
 	MaxAggregation            AggregationType = "max_agg"
 	UniqueCountAggregation    AggregationType = "unique_count_agg"
 	RecurringCountAggregation AggregationType = "recurring_count_agg"
+	WeightedSumAggregation    AggregationType = "weighted_sum_agg"
+)
+
+type WeightedInterval string
+
+const (
+	SecondsInterval WeightedInterval = "seconds"
 )
 
 type BillableMetricParams struct {
@@ -28,13 +35,14 @@ type BillableMetricParams struct {
 }
 
 type BillableMetricInput struct {
-	Name            string                 `json:"name,omitempty"`
-	Code            string                 `json:"code,omitempty"`
-	Description     string                 `json:"description,omitempty"`
-	AggregationType AggregationType        `json:"aggregation_type,omitempty"`
-	Recurring       bool                   `json:"recurring,omitempty"`
-	FieldName       string                 `json:"field_name"`
-	Group           map[string]interface{} `json:"group,omitempty"`
+	Name             string                 `json:"name,omitempty"`
+	Code             string                 `json:"code,omitempty"`
+	Description      string                 `json:"description,omitempty"`
+	AggregationType  AggregationType        `json:"aggregation_type,omitempty"`
+	Recurring        bool                   `json:"recurring,omitempty"`
+	FieldName        string                 `json:"field_name"`
+	WeightedInterval WeightedInterval       `json:"weighted_interval,omitempty"`
+	Group            map[string]interface{} `json:"group,omitempty"`
 }
 
 type BillableMetricListInput struct {
@@ -57,6 +65,7 @@ type BillableMetric struct {
 	AggregationType          AggregationType        `json:"aggregation_type,omitempty"`
 	FieldName                string                 `json:"field_name"`
 	CreatedAt                time.Time              `json:"created_at,omitempty"`
+	WeightedInterval         *WeightedInterval      `json:"weighted_interval,omitempty"`
 	Group                    map[string]interface{} `json:"group,omitempty"`
 	ActiveSubscriptionsCount int                    `json:"active_subscriptions_count,omitempty"`
 	DraftInvoicesCount       int                    `json:"draft_invoices_count,omitempty"`

--- a/event.go
+++ b/event.go
@@ -15,7 +15,7 @@ type EventInput struct {
 	ExternalCustomerID     string                 `json:"external_customer_id,omitempty"`
 	ExternalSubscriptionID string                 `json:"external_subscription_id,omitempty"`
 	Code                   string                 `json:"code,omitempty"`
-	Timestamp              int64                  `json:"timestamp,omitempty"`
+	Timestamp              string                 `json:"timestamp,omitempty"`
 	Properties             map[string]interface{} `json:"properties,omitempty"`
 }
 


### PR DESCRIPTION
## Context

For metrics that are charged upon a time frame, Lago is not able to calculate correctly the charge. For instance, imagine you want to price the number of GB/seconds used by a server. Currently, you can either calculate the number of seconds used, or the number of Gigabytes used, but not both at the same time.

## Description

This PR adds:
- the new `Event#timestamp` format with miliseconds precision
- The new `weighted_sum_agg` aggregation value in the `BillableMetric#aggregation_type` enumeation
- The new `BillableMetric#weighted_interval` enum
