### PR TITLE
fix(coupon): Add missing coupons#terminated_at

### DIFF
--- a/coupon.go
+++ b/coupon.go
@@ -89,7 +89,7 @@ type Coupon struct {
 	AmountCents            int                   `json:"amount_cents,omitempty"`
 	AmountCurrency         Currency              `json:"amount_currency,omitempty"`
 	Expiration             CouponExpiration      `json:"expiration,omitempty"`
-	ExpirationDate         string                `json:"expiration_date,omitempty"`
+	ExpirationAt           *time.Time            `json:"expiration_at,omitempty"`
 	PercentageRate         float64               `json:"percentage_rate,omitempty,string"`
 	CouponType             CouponCalculationType `json:"coupon_type,omitempty"`
 	Frequency              CouponFrequency       `json:"frequency,omitempty"`
@@ -100,6 +100,7 @@ type Coupon struct {
 	BillableMetricCodes    []string              `json:"billable_metric_codes,omitempty"`
 	FrequencyDuration      int                   `json:"frequency_duration,omitempty"`
 	CreatedAt              time.Time             `json:"created_at,omitempty"`
+	TerminatedAt           *time.Time            `json:"terminated_at,omitempty"`
 }
 
 type AppliedCouponResult struct {


### PR DESCRIPTION
## Context

Call to `GET /v1/api/coupons/:code` is missing the `terminated_at` value

## Description

This PR is adding the missing field in the `V1::CouponSerializer`