### PR TITLE
feat(invoice_display_name): Add invoice display name

### DIFF
--- a/add_on.go
+++ b/add_on.go
@@ -19,7 +19,7 @@ type AddOnParams struct {
 
 type AddOnInput struct {
 	Name								string `json:"name,omitempty"`
-	InvoiceDisplayName	string `json:"invoice_display_name"`
+	InvoiceDisplayName	string `json:"invoice_display_name,omitempty"`
 	Code								string `json:"code,omitempty"`
 	Description					string `json:"description,omitempty"`
 
@@ -43,7 +43,7 @@ type AddOnResult struct {
 type AddOn struct {
 	LagoID							uuid.UUID `json:"lago_id,omitempty"`
 	Name								string    `json:"name,omitempty"`
-	InvoiceDisplayName	string    `json:"invoice_display_name"`
+	InvoiceDisplayName	string    `json:"invoice_display_name,omitempty"`
 	Code								string    `json:"code,omitempty"`
 	Description					string    `json:"description,omitempty"`
 

--- a/add_on.go
+++ b/add_on.go
@@ -18,9 +18,10 @@ type AddOnParams struct {
 }
 
 type AddOnInput struct {
-	Name        string `json:"name,omitempty"`
-	Code        string `json:"code,omitempty"`
-	Description string `json:"description,omitempty"`
+	Name								string `json:"name,omitempty"`
+	InvoiceDisplayName	string `json:"invoice_display_name"`
+	Code								string `json:"code,omitempty"`
+	Description					string `json:"description,omitempty"`
 
 	AmountCents    int      `json:"amount_cents,omitempty"`
 	AmountCurrency Currency `json:"amount_currency,omitempty"`
@@ -40,10 +41,11 @@ type AddOnResult struct {
 }
 
 type AddOn struct {
-	LagoID      uuid.UUID `json:"lago_id,omitempty"`
-	Name        string    `json:"name,omitempty"`
-	Code        string    `json:"code,omitempty"`
-	Description string    `json:"description,omitempty"`
+	LagoID							uuid.UUID `json:"lago_id,omitempty"`
+	Name								string    `json:"name,omitempty"`
+	InvoiceDisplayName	string    `json:"invoice_display_name"`
+	Code								string    `json:"code,omitempty"`
+	Description					string    `json:"description,omitempty"`
 
 	AmountCents    int      `json:"amount_cents,omitempty"`
 	AmountCurrency Currency `json:"amount_currency,omitempty"`

--- a/charge.go
+++ b/charge.go
@@ -25,7 +25,7 @@ type Charge struct {
 	CreatedAt            time.Time              `json:"created_at,omitempty"`
 	PayInAdvance         bool                   `json:"pay_in_advance,omitempty"`
 	Invoiceable          bool                   `json:"invoiceable,omitempty"`
-	InvoiceDisplayName   string                 `json:"invoice_display_name"`
+	InvoiceDisplayName   string                 `json:"invoice_display_name,omitempty"`
 	Prorated             bool                   `json:"prorated,omitempty"`
 	MinAmountCents       int                    `json:"min_amount_cents,omitempty"`
 	Properties           map[string]interface{} `json:"properties,omitempty"`
@@ -37,5 +37,5 @@ type Charge struct {
 type GroupProperties struct {
 	GroupID             uuid.UUID              `json:"group_id"`
 	Values              map[string]interface{} `json:"values"`
-	InvoiceDisplayName  string                 `json:"invoice_display_name"`
+	InvoiceDisplayName  string                 `json:"invoice_display_name,omitempty"`
 }

--- a/charge.go
+++ b/charge.go
@@ -25,7 +25,6 @@ type Charge struct {
 	CreatedAt            time.Time              `json:"created_at,omitempty"`
 	PayInAdvance         bool                   `json:"pay_in_advance,omitempty"`
 	Invoiceable          bool                   `json:"invoiceable,omitempty"`
-	Invoiceable          bool                   `json:"invoiceable,omitempty"`
 	InvoiceDisplayName   string                 `json:"invoice_display_name"`
 	Prorated             bool                   `json:"prorated,omitempty"`
 	MinAmountCents       int                    `json:"min_amount_cents,omitempty"`

--- a/charge.go
+++ b/charge.go
@@ -25,6 +25,8 @@ type Charge struct {
 	CreatedAt            time.Time              `json:"created_at,omitempty"`
 	PayInAdvance         bool                   `json:"pay_in_advance,omitempty"`
 	Invoiceable          bool                   `json:"invoiceable,omitempty"`
+	Invoiceable          bool                   `json:"invoiceable,omitempty"`
+	InvoiceDisplayName   string                 `json:"invoice_display_name"`
 	Prorated             bool                   `json:"prorated,omitempty"`
 	MinAmountCents       int                    `json:"min_amount_cents,omitempty"`
 	Properties           map[string]interface{} `json:"properties,omitempty"`
@@ -34,6 +36,7 @@ type Charge struct {
 }
 
 type GroupProperties struct {
-	GroupID uuid.UUID              `json:"group_id"`
-	Values  map[string]interface{} `json:"values"`
+	GroupID             uuid.UUID              `json:"group_id"`
+	Values              map[string]interface{} `json:"values"`
+	InvoiceDisplayName  string                 `json:"invoice_display_name"`
 }

--- a/fee.go
+++ b/fee.go
@@ -77,11 +77,12 @@ type FeeListInput struct {
 }
 
 type FeeItem struct {
-	Type       FeeType     `json:"type,omitempty"`
-	Code       string      `json:"code,omitempty"`
-	Name       string      `json:"name,omitempty"`
-	LagoItemID uuid.UUID   `json:"lago_item_id,omitempty"`
-	ItemType   FeeItemType `json:"item_type,omitempty"`
+	Type       							FeeType     `json:"type,omitempty"`
+	Code       							string      `json:"code,omitempty"`
+	Name      							string      `json:"name,omitempty"`
+	InvoiceDisplayName			string      `json:"invoice_display_name"`
+	LagoItemID 							uuid.UUID   `json:"lago_item_id,omitempty"`
+	ItemType   							FeeItemType `json:"item_type,omitempty"`
 }
 
 type FeeAppliedTax struct {
@@ -116,6 +117,7 @@ type Fee struct {
 	Invoiceable         bool    `json:"invoiceable,omitempty"`
 	FromDate            string  `json:"from_date,omitempty"`
 	ToDate              string  `json:"to_date,omitempty"`
+	InvoiceDisplayName	string  `json:"invoice_display_name"`
 
 	Units       string `json:"units,omitempty"`
 	Description string `json:"description,omitempty"`

--- a/fee.go
+++ b/fee.go
@@ -80,7 +80,7 @@ type FeeItem struct {
 	Type       							FeeType     `json:"type,omitempty"`
 	Code       							string      `json:"code,omitempty"`
 	Name      							string      `json:"name,omitempty"`
-	InvoiceDisplayName			string      `json:"invoice_display_name"`
+	InvoiceDisplayName			string      `json:"invoice_display_name,omitempty"`
 	LagoItemID 							uuid.UUID   `json:"lago_item_id,omitempty"`
 	ItemType   							FeeItemType `json:"item_type,omitempty"`
 }
@@ -117,7 +117,7 @@ type Fee struct {
 	Invoiceable         bool    `json:"invoiceable,omitempty"`
 	FromDate            string  `json:"from_date,omitempty"`
 	ToDate              string  `json:"to_date,omitempty"`
-	InvoiceDisplayName	string  `json:"invoice_display_name"`
+	InvoiceDisplayName	string  `json:"invoice_display_name,omitempty"`
 
 	Units       string `json:"units,omitempty"`
 	Description string `json:"description,omitempty"`

--- a/invoice.go
+++ b/invoice.go
@@ -61,7 +61,7 @@ type InvoiceMetadataInput struct {
 
 type InvoiceFeesInput struct {
 	AddOnCode       		string   `json:"add_on_code,omitempty"`
-	InvoiceDisplayName	string   `json:"invoice_display_name"`
+	InvoiceDisplayName	string   `json:"invoice_display_name,omitempty"`
 	UnitAmountCents 		int      `json:"unit_amount_cents,omitempty"`
 	Description     		string   `json:"description,omitempty"`
 	Units           		float32  `json:"units,omitempty"`

--- a/invoice.go
+++ b/invoice.go
@@ -60,11 +60,12 @@ type InvoiceMetadataInput struct {
 }
 
 type InvoiceFeesInput struct {
-	AddOnCode       string   `json:"add_on_code,omitempty"`
-	UnitAmountCents int      `json:"unit_amount_cents,omitempty"`
-	Description     string   `json:"description,omitempty"`
-	Units           float32  `json:"units,omitempty"`
-	TaxCodes        []string `json:"tax_codes,omitempty"`
+	AddOnCode       		string   `json:"add_on_code,omitempty"`
+	InvoiceDisplayName	string   `json:"invoice_display_name"`
+	UnitAmountCents 		int      `json:"unit_amount_cents,omitempty"`
+	Description     		string   `json:"description,omitempty"`
+	Units           		float32  `json:"units,omitempty"`
+	TaxCodes        		[]string `json:"tax_codes,omitempty"`
 }
 
 type InvoiceMetadataResponse struct {

--- a/plan.go
+++ b/plan.go
@@ -47,17 +47,18 @@ type PlanChargeInput struct {
 }
 
 type PlanInput struct {
-	Name              string            `json:"name,omitempty"`
-	Code              string            `json:"code,omitempty"`
-	Interval          PlanInterval      `json:"interval,omitempty"`
-	Description       string            `json:"description,omitempty"`
-	AmountCents       int               `json:"amount_cents"`
-	AmountCurrency    Currency          `json:"amount_currency,omitempty"`
-	PayInAdvance      bool              `json:"pay_in_advance"`
-	BillChargeMonthly bool              `json:"bill_charge_monthly"`
-	TrialPeriod       float32           `json:"trial_period"`
-	Charges           []PlanChargeInput `json:"charges,omitempty"`
-	TaxCodes          []string          `json:"tax_codes,omitempty"`
+	Name              	string            `json:"name,omitempty"`
+	InvoiceDisplayName	string            `json:"invoice_display_name"`
+	Code              	string            `json:"code,omitempty"`
+	Interval          	PlanInterval      `json:"interval,omitempty"`
+	Description       	string            `json:"description,omitempty"`
+	AmountCents       	int               `json:"amount_cents"`
+	AmountCurrency    	Currency          `json:"amount_currency,omitempty"`
+	PayInAdvance      	bool              `json:"pay_in_advance"`
+	BillChargeMonthly 	bool              `json:"bill_charge_monthly"`
+	TrialPeriod       	float32           `json:"trial_period"`
+	Charges           	[]PlanChargeInput `json:"charges,omitempty"`
+	TaxCodes          	[]string          `json:"tax_codes,omitempty"`
 }
 
 type PlanListInput struct {
@@ -68,6 +69,7 @@ type PlanListInput struct {
 type Plan struct {
 	LagoID                   uuid.UUID    `json:"lago_id"`
 	Name                     string       `json:"name,omitempty"`
+	InvoiceDisplayName       string       `json:"invoice_display_name"`
 	Code                     string       `json:"code,omitempty"`
 	Interval                 PlanInterval `json:"interval,omitempty"`
 	Description              string       `json:"description,omitempty"`

--- a/plan.go
+++ b/plan.go
@@ -48,7 +48,7 @@ type PlanChargeInput struct {
 
 type PlanInput struct {
 	Name              	string            `json:"name,omitempty"`
-	InvoiceDisplayName	string            `json:"invoice_display_name"`
+	InvoiceDisplayName	string            `json:"invoice_display_name,omitempty"`
 	Code              	string            `json:"code,omitempty"`
 	Interval          	PlanInterval      `json:"interval,omitempty"`
 	Description       	string            `json:"description,omitempty"`
@@ -69,7 +69,7 @@ type PlanListInput struct {
 type Plan struct {
 	LagoID                   uuid.UUID    `json:"lago_id"`
 	Name                     string       `json:"name,omitempty"`
-	InvoiceDisplayName       string       `json:"invoice_display_name"`
+	InvoiceDisplayName       string       `json:"invoice_display_name,omitempty"`
 	Code                     string       `json:"code,omitempty"`
 	Interval                 PlanInterval `json:"interval,omitempty"`
 	Description              string       `json:"description,omitempty"`


### PR DESCRIPTION
## Context

Add a custom name to display on invoice for subscription fee and charges

## Description

When generating an invoice, don't display the name of the plan or the name of the billable metrics to the customer.