### PR TITLE
made PlanOverridesInput struct in the SubscriptionInput a pointer

### DIFF
--- a/subscription.go
+++ b/subscription.go
@@ -62,14 +62,14 @@ type PlanOverridesInput struct {
 }
 
 type SubscriptionInput struct {
-	ExternalCustomerID string             `json:"external_customer_id,omitempty"`
-	PlanCode           string             `json:"plan_code,omitempty"`
-	SubscriptionAt     *time.Time         `json:"subscription_at,omitempty"`
-	EndingAt           *time.Time         `json:"ending_at,omitempty"`
-	BillingTime        BillingTime        `json:"billing_time,omitempty"`
-	PlanOverrides      PlanOverridesInput `json:"plan_overrides,omitempty"`
-	ExternalID         string             `json:"external_id"`
-	Name               string             `json:"name"`
+	ExternalCustomerID string              `json:"external_customer_id,omitempty"`
+	PlanCode           string              `json:"plan_code,omitempty"`
+	SubscriptionAt     *time.Time          `json:"subscription_at,omitempty"`
+	EndingAt           *time.Time          `json:"ending_at,omitempty"`
+	BillingTime        BillingTime         `json:"billing_time,omitempty"`
+	PlanOverrides      *PlanOverridesInput `json:"plan_overrides,omitempty"`
+	ExternalID         string              `json:"external_id"`
+	Name               string              `json:"name"`
 }
 
 type SubscriptionTerminateInput struct {


### PR DESCRIPTION
Hey lago devs,
After digging around a bit and a conversation with one of your devs this bug was found.
This prevented us from creating subscriptions in the newest version of this client. because it wanted to send a PlanOverridesInput along without any actual values.

Omitempty only omits the field if the value in that field is a nil value. unfortunately an empty struct does not count as a nil value.
(direct quote from the docs "The "omitempty" option specifies that the field should be omitted from the encoding if the field has an empty value, defined as false, 0, a nil pointer, a nil interface value, and any empty array, slice, map, or string.")
By making it a pointer we make sure that the value is a nil pointer and thus is omitted from the request.

A recommendation is to have any values that are optional in the API be a pointer in the go client. This also make it a bit more clear from the go client itself which values are optional and which are not just by looking at the structs here.