### PR TITLE
feat(coupon): Add CouponName property to AppliedCoupon

### DIFF
--- a/coupon.go
+++ b/coupon.go
@@ -137,6 +137,7 @@ type AppliedCoupon struct {
 	LagoCustomerID     uuid.UUID           `json:"lago_customer_id,omitempty"`
 	Status             AppliedCouponStatus `json:"status,omitempty"`
 
+	CouponName         string              `json:"coupon_name,omitempty"`
 	CouponCode     string   `json:"coupon_code,omitempty"`
 	AmountCents    int      `json:"amount_cents,omitempty"`
 	AmountCurrency Currency `json:"amount_currency,omitempty"`


### PR DESCRIPTION
## Pull Request template

Originally spawned by this Roadmap item: https://getlago.canny.io/developer-experience/p/add-couponname-to-appliedcoupon-object the `List all applied coupons` endpoint now exposes the `coupon_name` but the property is still missing in the golang `AppliedCoupon` type.

This PR adds the `coupon_name` to the `AppliedCoupon` type and makes it accessible to the user
