### PR TITLE
replace PreciseUnitAmount type string to int

### DIFF
--- a/fee.go
+++ b/fee.go
@@ -110,7 +110,7 @@ type Fee struct {
 	AmountCents         int                    `json:"amount_cents,omitempty"`
 	AmountDetails       map[string]interface{} `json:"amount_details,omitempty"`
 	UnitAmountCents     int                    `json:"unit_amount_cents,omitempty"` // deprecated
-	PreciseUnitAmount   int                    `json:"precise_unit_amount,omitempty"`
+	PreciseUnitAmount   string                 `json:"precise_unit_amount,omitempty"`
 	AmountCurrency      string                 `json:"amount_currency,omitempty"`
 	TaxesAmountCents    int                    `json:"taxes_amount_cents,omitempty"`
 	TaxesRate           float32                `json:"taxes_rate,omitempty"`


### PR DESCRIPTION
Hi team,

I have noticed a change in the PreciseUnitAmount field of the Fees object that used to be an int, but has been changed to a string in one of your last updates. This broke our invoicing flow so I've made a PR!