### PR TITLE
fix(events): mark properties as object rather than string

### DIFF
--- a/event.go
+++ b/event.go
@@ -41,16 +41,16 @@ type EventResult struct {
 }
 
 type Event struct {
-	LagoID                 uuid.UUID         `json:"lago_id"`
-	TransactionID          string            `json:"transaction_id"`
-	LagoCustomerID         *uuid.UUID        `json:"lago_customer_id,omitempty"`
-	ExternalCustomerID     string            `json:"external_customer_id,omitempty"`
-	Code                   string            `json:"code,omitempty"`
-	Timestamp              time.Time         `json:"timestamp"`
-	Properties             map[string]string `json:"properties,omitempty"`
-	LagoSubscriptionID     *uuid.UUID        `json:"lago_subscription_id,omitempty"`
-	ExternalSubscriptionID string            `json:"external_subscription_id,omitempty"`
-	CreatedAt              time.Time         `json:"created_at"`
+	LagoID                 uuid.UUID              `json:"lago_id"`
+	TransactionID          string                 `json:"transaction_id"`
+	LagoCustomerID         *uuid.UUID             `json:"lago_customer_id,omitempty"`
+	ExternalCustomerID     string                 `json:"external_customer_id,omitempty"`
+	Code                   string                 `json:"code,omitempty"`
+	Timestamp              time.Time              `json:"timestamp"`
+	Properties             map[string]interface{} `json:"properties,omitempty"`
+	LagoSubscriptionID     *uuid.UUID             `json:"lago_subscription_id,omitempty"`
+	ExternalSubscriptionID string                 `json:"external_subscription_id,omitempty"`
+	CreatedAt              time.Time              `json:"created_at"`
 }
 
 func (c *Client) Event() *EventRequest {


### PR DESCRIPTION
Per [docs](https://docs.getlago.com/api-reference/events/event-object#:~:text=of%20event%20reception.-,properties,-object) it is an object that can contain value as string or number, and this will match in the same as in [`EventInput`](https://github.com/getlago/lago-go-client/blob/main/event.go#L25)