### PR TITLE
feat (document-numbering): add support for document numbering fields

### DIFF
--- a/organization.go
+++ b/organization.go
@@ -5,6 +5,13 @@ import (
 	"time"
 )
 
+type OrganizationDocumentNumbering string
+
+const (
+	DocumentNumberingPerCustomer     OrganizationDocumentNumbering = "per_customer"
+	DocumentNumberingPerOrganization OrganizationDocumentNumbering = "per_organization"
+)
+
 type OrganizationRequest struct {
 	client *Client
 }
@@ -28,21 +35,23 @@ type OrganizationBillingConfiguration struct {
 type OrganizationInput struct {
 	Name string `json:"name,omitempty"`
 
-	Email                   string   `json:"email,omitempty"`
-	AddressLine1            string   `json:"address_line1,omitempty"`
-	AddressLine2            string   `json:"address_line2,omitempty"`
-	City                    string   `json:"city,omitempty"`
-	Zipcode                 string   `json:"zipcode,omitempty"`
-	State                   string   `json:"state,omitempty"`
-	Country                 string   `json:"country,omitempty"`
-	DefaultCurrency         Currency `json:"default_currency,omitempty"`
-	LegalName               string   `json:"legal_name,omitempty"`
-	LegalNumber             string   `json:"legal_number,omitempty"`
-	NetPaymentTerm          int      `json:"net_payment_term,omitempty"`
-	TaxIdentificationNumber string   `json:"tax_identification_number,omitempty"`
-	WebhookURL              string   `json:"webhook_url,omitempty"`
-	Timezone                string   `json:"timezone,omitempty"`
-	EmailSettings           []string `json:"email_settings,omitempty"`
+	Email                   string                        `json:"email,omitempty"`
+	AddressLine1            string                        `json:"address_line1,omitempty"`
+	AddressLine2            string                        `json:"address_line2,omitempty"`
+	City                    string                        `json:"city,omitempty"`
+	Zipcode                 string                        `json:"zipcode,omitempty"`
+	State                   string                        `json:"state,omitempty"`
+	Country                 string                        `json:"country,omitempty"`
+	DefaultCurrency         Currency                      `json:"default_currency,omitempty"`
+	LegalName               string                        `json:"legal_name,omitempty"`
+	LegalNumber             string                        `json:"legal_number,omitempty"`
+	DocumentNumbering       OrganizationDocumentNumbering `json:"document_numbering,omitempty"`
+	DocumentNumberPrefix    string                        `json:"document_number_prefix,omitempty"`
+	NetPaymentTerm          int                           `json:"net_payment_term,omitempty"`
+	TaxIdentificationNumber string                        `json:"tax_identification_number,omitempty"`
+	WebhookURL              string                        `json:"webhook_url,omitempty"`
+	Timezone                string                        `json:"timezone,omitempty"`
+	EmailSettings           []string                      `json:"email_settings,omitempty"`
 
 	BillingConfiguration OrganizationBillingConfigurationInput `json:"billing_configuration,omitempty"`
 }
@@ -54,22 +63,24 @@ type OrganizationResult struct {
 type Organization struct {
 	Name string `json:"name,omitempty"`
 
-	Email                   string   `json:"email,omitempty"`
-	AddressLine1            string   `json:"address_line1,omitempty"`
-	AddressLine2            string   `json:"address_line2,omitempty"`
-	City                    string   `json:"city,omitempty"`
-	Zipcode                 string   `json:"zipcode,omitempty"`
-	State                   string   `json:"state,omitempty"`
-	Country                 string   `json:"country,omitempty"`
-	DefaultCurrency         Currency `json:"default_currency,omitempty"`
-	LegalName               string   `json:"legal_name,omitempty"`
-	LegalNumber             string   `json:"legal_number,omitempty"`
-	NetPaymentTerm          int      `json:"net_payment_term,omitempty"`
-	TaxIdentificationNumber string   `json:"tax_identification_number,omitempty"`
-	WebhookURL              string   `json:"webhook_url,omitempty"`
-	WebhookURLs             []string `json:"webhook_urls,omitempty"`
-	Timezone                string   `json:"timezone,omitempty"`
-	EmailSettings           []string `json:"email_settings,omitempty"`
+	Email                   string                        `json:"email,omitempty"`
+	AddressLine1            string                        `json:"address_line1,omitempty"`
+	AddressLine2            string                        `json:"address_line2,omitempty"`
+	City                    string                        `json:"city,omitempty"`
+	Zipcode                 string                        `json:"zipcode,omitempty"`
+	State                   string                        `json:"state,omitempty"`
+	Country                 string                        `json:"country,omitempty"`
+	DefaultCurrency         Currency                      `json:"default_currency,omitempty"`
+	LegalName               string                        `json:"legal_name,omitempty"`
+	LegalNumber             string                        `json:"legal_number,omitempty"`
+	DocumentNumbering       OrganizationDocumentNumbering `json:"document_numbering,omitempty"`
+	DocumentNumberPrefix    string                        `json:"document_number_prefix,omitempty"`
+	NetPaymentTerm          int                           `json:"net_payment_term,omitempty"`
+	TaxIdentificationNumber string                        `json:"tax_identification_number,omitempty"`
+	WebhookURL              string                        `json:"webhook_url,omitempty"`
+	WebhookURLs             []string                      `json:"webhook_urls,omitempty"`
+	Timezone                string                        `json:"timezone,omitempty"`
+	EmailSettings           []string                      `json:"email_settings,omitempty"`
 
 	BillingConfiguration OrganizationBillingConfiguration `json:"billing_configuration,omitempty"`
 


### PR DESCRIPTION
## Context

Before, it was not possible to adapt document number. With this feature it will be enabled to switch between `per_customer` and `per_organization` document numbering logic. Also, it will be possible to edit number prefix.

## Description

This PR adds support for new document numbering fields