### PR TITLE
feat(grouped-by): Add new fields

### DIFF
--- a/customer.go
+++ b/customer.go
@@ -112,8 +112,27 @@ type CustomerChargeUsage struct {
 	AmountCents    int      `json:"amount_cents,omitempty"`
 	AmountCurrency Currency `json:"amount_currency,omitempty"`
 
-	Charge         *Charge         `json:"charge,omitempty"`
-	BillableMetric *BillableMetric `json:"billable_metric,omitempty"`
+	Charge         *Charge                      `json:"charge,omitempty"`
+	BillableMetric *BillableMetric              `json:"billable_metric,omitempty"`
+	Groups         []CustomerChargeGroupdUsage  `json:"groups,omitempty"`
+	GroupedUsage   []CustomerChargeGroupedUsage `json:"grouped_usage,omitempty"`
+}
+
+type CustomerChargeGroupdUsage struct {
+	LagoId      uuid.UUID `json:"lago_id,omitempty"`
+	Key         string    `json:"key,omitempty"`
+	Value       string    `json:"value,omitempty"`
+	AmountCents int       `json:"amount_cents,omitempty"`
+	EventsCount int       `json:"events_count,omitempty"`
+	Units       string    `json:"units,omitempty"`
+}
+
+type CustomerChargeGroupedUsage struct {
+	AmountCents int                         `json:"amount_cents,omitempty"`
+	EventsCount int                         `json:"events_count,omitempty"`
+	Units       string                      `json:"units,omitempty"`
+	GroupedBy   map[string]interface{}      `json:"grouped_by,omitempty"`
+	Groups      []CustomerChargeGroupdUsage `json:"groups,omitempty"`
 }
 
 type CustomerUsage struct {

--- a/fee.go
+++ b/fee.go
@@ -77,13 +77,14 @@ type FeeListInput struct {
 }
 
 type FeeItem struct {
-	Type                    FeeType     `json:"type,omitempty"`
-	Code                    string      `json:"code,omitempty"`
-	Name                    string      `json:"name,omitempty"`
-	InvoiceDisplayName      string      `json:"invoice_display_name,omitempty"`
-	GroupInvoiceDisplayName string      `json:"group_invoice_display_name,omitempty"`
-	LagoItemID              uuid.UUID   `json:"lago_item_id,omitempty"`
-	ItemType                FeeItemType `json:"item_type,omitempty"`
+	Type                    FeeType                `json:"type,omitempty"`
+	Code                    string                 `json:"code,omitempty"`
+	Name                    string                 `json:"name,omitempty"`
+	InvoiceDisplayName      string                 `json:"invoice_display_name,omitempty"`
+	GroupInvoiceDisplayName string                 `json:"group_invoice_display_name,omitempty"`
+	LagoItemID              uuid.UUID              `json:"lago_item_id,omitempty"`
+	ItemType                FeeItemType            `json:"item_type,omitempty"`
+	GroupedBy               map[string]interface{} `json:"grouped_by,omitempty"`
 }
 
 type FeeAppliedTax struct {


### PR DESCRIPTION
## Context

Some customers have requested a way to group usage fees on an invoice using an event property. The same charge model properties should be applied to each group. The logic will only apply to `standard` charge model.

## Description

This PR adds all the new fields related to the feature
