### PR TITLE
feat(filter): Add filter fields

### DIFF
--- a/billable_metric.go
+++ b/billable_metric.go
@@ -43,6 +43,7 @@ type BillableMetricInput struct {
 	FieldName        string                 `json:"field_name"`
 	WeightedInterval WeightedInterval       `json:"weighted_interval,omitempty"`
 	Group            map[string]interface{} `json:"group,omitempty"`
+	Filters          []BillableMetricFilter `json:"filters,omitempty"`
 }
 
 type BillableMetricListInput struct {
@@ -56,6 +57,11 @@ type BillableMetricResult struct {
 	Meta            Metadata         `json:"meta,omitempty"`
 }
 
+type BillableMetricFilter struct {
+	Key    string   `json:"key,omitempty"`
+	Values []string `json:"values,omitempty"`
+}
+
 type BillableMetric struct {
 	LagoID                   uuid.UUID              `json:"lago_id"`
 	Name                     string                 `json:"name,omitempty"`
@@ -67,6 +73,7 @@ type BillableMetric struct {
 	CreatedAt                time.Time              `json:"created_at,omitempty"`
 	WeightedInterval         *WeightedInterval      `json:"weighted_interval,omitempty"`
 	Group                    map[string]interface{} `json:"group,omitempty"`
+	Filters                  []BillableMetricFilter `json:"filters,omitempty"`
 	ActiveSubscriptionsCount int                    `json:"active_subscriptions_count,omitempty"`
 	DraftInvoicesCount       int                    `json:"draft_invoices_count,omitempty"`
 	PlansCount               int                    `json:"plans_count,omitempty"`

--- a/charge.go
+++ b/charge.go
@@ -17,6 +17,12 @@ const (
 	VolumeChargeModel              ChargeModel = "volume"
 )
 
+type ChargeFilter struct {
+	InvoiceDisplayName string                 `json:"invoice_display_name,omitempty"`
+	Properties         map[string]interface{} `json:"properties,omitempty"`
+	Values             map[string]interface{} `json:"values,omitempty"`
+}
+
 type Charge struct {
 	LagoID               uuid.UUID              `json:"lago_id,omitempty"`
 	LagoBillableMetricID uuid.UUID              `json:"lago_billable_metric_id,omitempty"`
@@ -30,12 +36,13 @@ type Charge struct {
 	MinAmountCents       int                    `json:"min_amount_cents,omitempty"`
 	Properties           map[string]interface{} `json:"properties,omitempty"`
 	GroupProperties      []GroupProperties      `json:"group_properties,omitempty"`
+	Filters              []ChargeFilter         `json:"filters,omitempty"`
 
 	Taxes []Tax `json:"tax,omitempty"`
 }
 
 type GroupProperties struct {
-	GroupID             uuid.UUID              `json:"group_id"`
-	Values              map[string]interface{} `json:"values"`
-	InvoiceDisplayName  string                 `json:"invoice_display_name,omitempty"`
+	GroupID            uuid.UUID              `json:"group_id"`
+	Values             map[string]interface{} `json:"values"`
+	InvoiceDisplayName string                 `json:"invoice_display_name,omitempty"`
 }

--- a/customer.go
+++ b/customer.go
@@ -115,6 +115,7 @@ type CustomerChargeUsage struct {
 	Charge         *Charge                      `json:"charge,omitempty"`
 	BillableMetric *BillableMetric              `json:"billable_metric,omitempty"`
 	Groups         []CustomerChargeGroupdUsage  `json:"groups,omitempty"`
+	Filters        []CustomerChargeFilterUsage  `json:"filters,omitempty"`
 	GroupedUsage   []CustomerChargeGroupedUsage `json:"grouped_usage,omitempty"`
 }
 
@@ -127,12 +128,21 @@ type CustomerChargeGroupdUsage struct {
 	Units       string    `json:"units,omitempty"`
 }
 
+type CustomerChargeFilterUsage struct {
+	InvoiceDisplayName string                 `json:"invoice_display_name,omitempty"`
+	Values             map[string]interface{} `json:"value,omitempty"`
+	AmountCents        int                    `json:"amount_cents,omitempty"`
+	EventsCount        int                    `json:"events_count,omitempty"`
+	Units              string                 `json:"units,omitempty"`
+}
+
 type CustomerChargeGroupedUsage struct {
 	AmountCents int                         `json:"amount_cents,omitempty"`
 	EventsCount int                         `json:"events_count,omitempty"`
 	Units       string                      `json:"units,omitempty"`
 	GroupedBy   map[string]interface{}      `json:"grouped_by,omitempty"`
 	Groups      []CustomerChargeGroupdUsage `json:"groups,omitempty"`
+	Filters     []CustomerChargeFilterUsage `json:"filters,omitempty"`
 }
 
 type CustomerUsage struct {

--- a/fee.go
+++ b/fee.go
@@ -77,14 +77,16 @@ type FeeListInput struct {
 }
 
 type FeeItem struct {
-	Type                    FeeType                `json:"type,omitempty"`
-	Code                    string                 `json:"code,omitempty"`
-	Name                    string                 `json:"name,omitempty"`
-	InvoiceDisplayName      string                 `json:"invoice_display_name,omitempty"`
-	GroupInvoiceDisplayName string                 `json:"group_invoice_display_name,omitempty"`
-	LagoItemID              uuid.UUID              `json:"lago_item_id,omitempty"`
-	ItemType                FeeItemType            `json:"item_type,omitempty"`
-	GroupedBy               map[string]interface{} `json:"grouped_by,omitempty"`
+	Type                     FeeType                `json:"type,omitempty"`
+	Code                     string                 `json:"code,omitempty"`
+	Name                     string                 `json:"name,omitempty"`
+	InvoiceDisplayName       string                 `json:"invoice_display_name,omitempty"`
+	GroupInvoiceDisplayName  string                 `json:"group_invoice_display_name,omitempty"`
+	FilterInvoiceDisplayName string                 `json:"filter_invoice_display_name,omitempty"`
+	Filters                  map[string]interface{} `json:"filters,omitempty"`
+	LagoItemID               uuid.UUID              `json:"lago_item_id,omitempty"`
+	ItemType                 FeeItemType            `json:"item_type,omitempty"`
+	GroupedBy                map[string]interface{} `json:"grouped_by,omitempty"`
 }
 
 type FeeAppliedTax struct {
@@ -103,6 +105,7 @@ type FeeAppliedTax struct {
 type Fee struct {
 	LagoID                 uuid.UUID `json:"lago_id,omitempty"`
 	LagoGroupID            uuid.UUID `json:"lago_group_id,omitempty"`
+	LagoChargeFilterID     uuid.UUID `json:"lago_charge_filter_id,omitempty"`
 	LagoInvoiceID          uuid.UUID `json:"lago_invoice_id,omitempty"`
 	LagoTrueUpFeeID        uuid.UUID `json:"lago_true_up_fee_id,omitempty"`
 	LagoTrueUpParentFeeID  uuid.UUID `json:"lago_true_up_parent_fee_id,omitempty"`

--- a/plan.go
+++ b/plan.go
@@ -43,30 +43,31 @@ type PlanChargeInput struct {
 	MinAmountCents   int                    `json:"min_amount_cents,omitempty"`
 	Properties       map[string]interface{} `json:"properties"`
 	GroupProperties  []GroupProperties      `json:"group_properties,omitempty"`
+	Filters          []ChargeFilter         `json:"filters,omitempty"`
 
 	TaxCodes []string `json:"tax_codes,omitempty"`
 }
 
 type MinimumCommitmentInput struct {
-	AmountCents         int      `json:"amount_cents,omitempty"`
-	InvoiceDisplayName  string   `json:"invoice_display_name,omitempty"`
-	TaxCodes          	[]string `json:"tax_codes,omitempty"`
+	AmountCents        int      `json:"amount_cents,omitempty"`
+	InvoiceDisplayName string   `json:"invoice_display_name,omitempty"`
+	TaxCodes           []string `json:"tax_codes,omitempty"`
 }
 
 type PlanInput struct {
-	Name              	string                  `json:"name,omitempty"`
-	InvoiceDisplayName	string                  `json:"invoice_display_name,omitempty"`
-	Code              	string                  `json:"code,omitempty"`
-	Interval          	PlanInterval            `json:"interval,omitempty"`
-	Description       	string                  `json:"description,omitempty"`
-	AmountCents       	int                     `json:"amount_cents"`
-	AmountCurrency    	Currency                `json:"amount_currency,omitempty"`
-	PayInAdvance      	bool                    `json:"pay_in_advance"`
-	BillChargeMonthly 	bool                    `json:"bill_charge_monthly"`
-	TrialPeriod       	float32                 `json:"trial_period"`
-	Charges           	[]PlanChargeInput       `json:"charges,omitempty"`
-	MinimumCommitment   *MinimumCommitmentInput `json:"minimum_commitment,omitempty"`
-	TaxCodes          	[]string                `json:"tax_codes,omitempty"`
+	Name               string                  `json:"name,omitempty"`
+	InvoiceDisplayName string                  `json:"invoice_display_name,omitempty"`
+	Code               string                  `json:"code,omitempty"`
+	Interval           PlanInterval            `json:"interval,omitempty"`
+	Description        string                  `json:"description,omitempty"`
+	AmountCents        int                     `json:"amount_cents"`
+	AmountCurrency     Currency                `json:"amount_currency,omitempty"`
+	PayInAdvance       bool                    `json:"pay_in_advance"`
+	BillChargeMonthly  bool                    `json:"bill_charge_monthly"`
+	TrialPeriod        float32                 `json:"trial_period"`
+	Charges            []PlanChargeInput       `json:"charges,omitempty"`
+	MinimumCommitment  *MinimumCommitmentInput `json:"minimum_commitment,omitempty"`
+	TaxCodes           []string                `json:"tax_codes,omitempty"`
 }
 
 type PlanListInput struct {
@@ -75,13 +76,13 @@ type PlanListInput struct {
 }
 
 type MinimumCommitment struct {
-	LagoID              uuid.UUID    `json:"lago_id"`
-	PlanCode            string       `json:"plan_code,omitempty"`
-	InvoiceDisplayName	string       `json:"invoice_display_name,omitempty"`
-	AmountCents         int          `json:"amount_cents"`
-	Interval            PlanInterval `json:"interval,omitempty"`
-	CreatedAt           time.Time    `json:"created_at,omitempty"`
-	UpdatedAt           time.Time    `json:"updated_at,omitempty"`
+	LagoID             uuid.UUID    `json:"lago_id"`
+	PlanCode           string       `json:"plan_code,omitempty"`
+	InvoiceDisplayName string       `json:"invoice_display_name,omitempty"`
+	AmountCents        int          `json:"amount_cents"`
+	Interval           PlanInterval `json:"interval,omitempty"`
+	CreatedAt          time.Time    `json:"created_at,omitempty"`
+	UpdatedAt          time.Time    `json:"updated_at,omitempty"`
 
 	Taxes []Tax `json:"tax,omitempty"`
 }
@@ -98,9 +99,9 @@ type Plan struct {
 	PayInAdvance             bool               `json:"pay_in_advance,omitempty"`
 	BillChargeMonthly        bool               `json:"bill_charge_monthly,omitempty"`
 	ActiveSubscriptionsCount int                `json:"active_subscriptions_count,omitempty"`
-	DraftInvoicesCount       int          	    `json:"draft_invoices_count,omitempty"`
+	DraftInvoicesCount       int                `json:"draft_invoices_count,omitempty"`
 	Charges                  []Charge           `json:"charges,omitempty"`
-	MinimumCommitment 	  	 *MinimumCommitment `json:"minimum_commitment"`
+	MinimumCommitment        *MinimumCommitment `json:"minimum_commitment"`
 
 	Taxes []Tax `json:"taxes,omitempty"`
 }

--- a/subscription.go
+++ b/subscription.go
@@ -46,6 +46,7 @@ type ChargeOverridesInput struct {
 	MinAmountCents     int                    `json:"min_amount_cents,omitempty"`
 	Properties         map[string]interface{} `json:"properties"`
 	GroupProperties    []GroupProperties      `json:"group_properties,omitempty"`
+	Filters            []ChargeFilter         `json:"filters,omitempty"`
 	TaxCodes           []string               `json:"tax_codes,omitempty"`
 }
 


### PR DESCRIPTION
## Context

Lago is not currently supporting more than 2 levels of event grouping (parent → children)

The goal of this feature is to allow more flexibility of event grouping by allowing an unlimited level of grouping and making it easier to define default charge properties for events based on their properties.

## Description

This PR is related to https://github.com/getlago/lago-openapi/pull/210
It adds the new filter fields in both input and output objects