### PR TITLE
Update Lib Version in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a Go wrapper for Lago API
 ## Installation
 
 ```shell
-go get github.com/getlago/lago-go-client@v1.1.0
+go get github.com/getlago/lago-go-client@v1
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a Go wrapper for Lago API
 ## Installation
 
 ```shell
-go get github.com/getlago/lago-go-client@v0.15.2-alpha
+go get github.com/getlago/lago-go-client@v1.1.0
 ```
 
 ## Usage


### PR DESCRIPTION
## What

Simply updates the mentioned version on the readme for easier copying, especially now that a major version has been hit, I think it makes sense to update the version number there.

And by specifying `@v1` in the readme everyone who copies it will get the latest version that is available at that time without the need to always update it further