### PR TITLE
feat(wallet): Add transaction_status to wallet object

### DIFF
--- a/wallet_transaction.go
+++ b/wallet_transaction.go
@@ -16,6 +16,14 @@ const (
 	WalletTransactionStatusSettled WalletTransactionStatus = "settled"
 )
 
+type TransactionStatus string
+
+const (
+	Paid    TransactionStatus = "paid"
+	Offered TransactionStatus = "offered"
+	Voided  TransactionStatus = "voided"
+)
+
 type TransactionType string
 
 const (
@@ -28,11 +36,12 @@ type WalletTransactionRequest struct {
 }
 
 type WalletTransactionListInput struct {
-	PerPage         int                     `json:"per_page,omitempty,string"`
-	Page            int                     `json:"page,omitempty,string"`
-	WalletID        string                  `json:"wallet_id,omitempty"`
-	Status          WalletTransactionStatus `json:"status,omitempty"`
-	TransactionType TransactionType         `json:"transaction_type,omitempty"`
+	PerPage           int                     `json:"per_page,omitempty,string"`
+	Page              int                     `json:"page,omitempty,string"`
+	WalletID          string                  `json:"wallet_id,omitempty"`
+	Status            WalletTransactionStatus `json:"status,omitempty"`
+	TransactionStatus TransactionStatus       `json:"transaction_status,omitempty"`
+	TransactionType   TransactionType         `json:"transaction_type,omitempty"`
 }
 
 type WalletTransactionParams struct {


### PR DESCRIPTION
## Context

We want to differentiate a free wallet transaction vs. a paid wallet transaction.
And be able to void some wallet transactions.

## Description

This PR aims to add the `transaction_status` field for Wallet.
