### PR TITLE
feat(wallet): Rename transaction statuses for wallet

### DIFF
--- a/wallet_transaction.go
+++ b/wallet_transaction.go
@@ -19,9 +19,9 @@ const (
 type TransactionStatus string
 
 const (
-	Paid    TransactionStatus = "paid"
-	Offered TransactionStatus = "offered"
-	Voided  TransactionStatus = "voided"
+	Purchased TransactionStatus = "purchased"
+	Granted   TransactionStatus = "granted"
+	Voided    TransactionStatus = "voided"
 )
 
 type TransactionType string


### PR DESCRIPTION
## Context

We want to differentiate a free wallet transaction vs. a paid wallet transaction.
And be able to void some wallet transactions.

## Description

This PR aims to rename:

- `paid` to `purchased`
- `offered` to `granted`

for the `transaction_status` field for Wallet.
