### PR TITLE
feat(wallet): Add voided_credits to WalletTransaction

### DIFF
--- a/wallet_transaction.go
+++ b/wallet_transaction.go
@@ -52,6 +52,7 @@ type WalletTransactionInput struct {
 	WalletID       string `json:"wallet_id,omitempty"`
 	PaidCredits    string `json:"paid_credits,omitempty"`
 	GrantedCredits string `json:"granted_credits,omitempty"`
+	VoidedCredits  string `json:"voided_credits,omitempty"`
 }
 
 type WalletTransactionResult struct {

--- a/wallet_transaction.go
+++ b/wallet_transaction.go
@@ -22,6 +22,7 @@ const (
 	Purchased TransactionStatus = "purchased"
 	Granted   TransactionStatus = "granted"
 	Voided    TransactionStatus = "voided"
+	Invoiced  TransactionStatus = "invoiced"
 )
 
 type TransactionType string


### PR DESCRIPTION
## Context

We want to differentiate a free wallet transaction vs. a paid wallet transaction.
And be able to void some wallet transactions.

## Description

This PR aims to create a voided wallet transaction.