### PR TITLE
feat(wallet): Rename wallet rule_type into trigger

### DIFF
--- a/wallet.go
+++ b/wallet.go
@@ -18,18 +18,18 @@ const (
 
 type RecurringTransactionRuleInput struct {
 	LagoID           uuid.UUID `json:"lago_id,omitempty"`
-	RuleType         string    `json:"rule_type,omitempty"`
 	Interval         string    `json:"interval,omitempty"`
 	ThresholdCredits string    `json:"threshold_credits,omitempty"`
+	Trigger          string    `json:"trigger,omitempty"`
 	PaidCredits      string    `json:"paid_credits,omitempty"`
 	GrantedCredits   string    `json:"granted_credits,omitempty"`
 }
 
 type RecurringTransactionRuleResponse struct {
 	LagoID           uuid.UUID `json:"lago_id,omitempty"`
-	RuleType         string    `json:"rule_type,omitempty"`
 	Interval         string    `json:"interval,omitempty"`
 	ThresholdCredits string    `json:"threshold_credits,omitempty"`
+	Trigger          string    `json:"trigger,omitempty"`
 	PaidCredits      string    `json:"paid_credits,omitempty"`
 	GrantedCredits   string    `json:"granted_credits,omitempty"`
 	CreatedAt        time.Time `json:"created_at,omitempty"`


### PR DESCRIPTION
## Context

After the release of real-time wallet version 1, some customers have expressed concerns about odd or missing behaviors.

## Description

The goal of this PR is to rename `Wallet#rule_type` into `Wallet#trigger`.