### PR TITLE
feat(wallet): Add method and target_ongoing_balance to recurring_transaction_rule

### DIFF
--- a/wallet.go
+++ b/wallet.go
@@ -17,22 +17,26 @@ const (
 )
 
 type RecurringTransactionRuleInput struct {
-	LagoID           uuid.UUID `json:"lago_id,omitempty"`
-	Interval         string    `json:"interval,omitempty"`
-	ThresholdCredits string    `json:"threshold_credits,omitempty"`
-	Trigger          string    `json:"trigger,omitempty"`
-	PaidCredits      string    `json:"paid_credits,omitempty"`
-	GrantedCredits   string    `json:"granted_credits,omitempty"`
+	LagoID               uuid.UUID `json:"lago_id,omitempty"`
+	Interval             string    `json:"interval,omitempty"`
+	Method               string    `json:"method,omitempty"`
+	TargetOngoingBalance string    `json:"target_ongoing_balance,omitempty"`
+	ThresholdCredits     string    `json:"threshold_credits,omitempty"`
+	Trigger              string    `json:"trigger,omitempty"`
+	PaidCredits          string    `json:"paid_credits,omitempty"`
+	GrantedCredits       string    `json:"granted_credits,omitempty"`
 }
 
 type RecurringTransactionRuleResponse struct {
-	LagoID           uuid.UUID `json:"lago_id,omitempty"`
-	Interval         string    `json:"interval,omitempty"`
-	ThresholdCredits string    `json:"threshold_credits,omitempty"`
-	Trigger          string    `json:"trigger,omitempty"`
-	PaidCredits      string    `json:"paid_credits,omitempty"`
-	GrantedCredits   string    `json:"granted_credits,omitempty"`
-	CreatedAt        time.Time `json:"created_at,omitempty"`
+	LagoID               uuid.UUID `json:"lago_id,omitempty"`
+	Interval             string    `json:"interval,omitempty"`
+	Method               string    `json:"method,omitempty"`
+	TargetOngoingBalance string    `json:"target_ongoing_balance,omitempty"`
+	ThresholdCredits     string    `json:"threshold_credits,omitempty"`
+	Trigger              string    `json:"trigger,omitempty"`
+	PaidCredits          string    `json:"paid_credits,omitempty"`
+	GrantedCredits       string    `json:"granted_credits,omitempty"`
+	CreatedAt            time.Time `json:"created_at,omitempty"`
 }
 
 type WalletRequest struct {

--- a/wallet.go
+++ b/wallet.go
@@ -17,26 +17,28 @@ const (
 )
 
 type RecurringTransactionRuleInput struct {
-	LagoID               uuid.UUID `json:"lago_id,omitempty"`
-	Interval             string    `json:"interval,omitempty"`
-	Method               string    `json:"method,omitempty"`
-	TargetOngoingBalance string    `json:"target_ongoing_balance,omitempty"`
-	ThresholdCredits     string    `json:"threshold_credits,omitempty"`
-	Trigger              string    `json:"trigger,omitempty"`
-	PaidCredits          string    `json:"paid_credits,omitempty"`
-	GrantedCredits       string    `json:"granted_credits,omitempty"`
+	LagoID               uuid.UUID  `json:"lago_id,omitempty"`
+	Interval             string     `json:"interval,omitempty"`
+	Method               string     `json:"method,omitempty"`
+	StartedAt            *time.Time `json:"started_at,omitempty"`
+	TargetOngoingBalance string     `json:"target_ongoing_balance,omitempty"`
+	ThresholdCredits     string     `json:"threshold_credits,omitempty"`
+	Trigger              string     `json:"trigger,omitempty"`
+	PaidCredits          string     `json:"paid_credits,omitempty"`
+	GrantedCredits       string     `json:"granted_credits,omitempty"`
 }
 
 type RecurringTransactionRuleResponse struct {
-	LagoID               uuid.UUID `json:"lago_id,omitempty"`
-	Interval             string    `json:"interval,omitempty"`
-	Method               string    `json:"method,omitempty"`
-	TargetOngoingBalance string    `json:"target_ongoing_balance,omitempty"`
-	ThresholdCredits     string    `json:"threshold_credits,omitempty"`
-	Trigger              string    `json:"trigger,omitempty"`
-	PaidCredits          string    `json:"paid_credits,omitempty"`
-	GrantedCredits       string    `json:"granted_credits,omitempty"`
-	CreatedAt            time.Time `json:"created_at,omitempty"`
+	LagoID               uuid.UUID  `json:"lago_id,omitempty"`
+	Interval             string     `json:"interval,omitempty"`
+	Method               string     `json:"method,omitempty"`
+	StartedAt            *time.Time `json:"started_at,omitempty"`
+	TargetOngoingBalance string     `json:"target_ongoing_balance,omitempty"`
+	ThresholdCredits     string     `json:"threshold_credits,omitempty"`
+	Trigger              string     `json:"trigger,omitempty"`
+	PaidCredits          string     `json:"paid_credits,omitempty"`
+	GrantedCredits       string     `json:"granted_credits,omitempty"`
+	CreatedAt            time.Time  `json:"created_at,omitempty"`
 }
 
 type WalletRequest struct {


### PR DESCRIPTION
## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/define-a-target-balance-to-reach-for-recurring-top-up

## Context

We want to allow users to top-up their wallets to reach a specific target balance.

We can currently define a fixed top-up but we want to add the ability to specify a dynamic top-up (target balance to reach).

## Description

The goal of this PR is to add:

- `method`
- `target_ongoing_balance`
- `started_at`

to `recurring_transaction_rule`