### PR TITLE
feat: implement error interface

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,6 +1,7 @@
 package lago
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 )
@@ -26,6 +27,19 @@ type Error struct {
 	ErrorCode      string `json:"code"`
 
 	ErrorDetail map[string][]string `json:"error_details,omitempty"`
+}
+
+func (e Error) Error() string {
+	type alias struct {
+		Error
+		Err string `json:"err,omitempty"`
+	}
+	err := alias{Error: e}
+	if e.Err != nil {
+		err.Err = e.Err.Error()
+	}
+	msg, _ := json.Marshal(&err)
+	return string(msg)
 }
 
 func (e ErrorCode) Error() string {

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,23 @@
+package lago
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestErrorErr(t *testing.T) {
+	var hasErr error = Error{
+		Err:            errors.New("type assertion failed"),
+		HTTPStatusCode: 422,
+		Message:        "Type assertion failed",
+	}
+	t.Logf("%s", hasErr.Error())
+}
+
+func TestErrorNoErr(t *testing.T) {
+	var noErr error = Error{
+		HTTPStatusCode: 500,
+		Message:        "500",
+	}
+	t.Logf("%s", noErr.Error())
+}


### PR DESCRIPTION
before: `lago.Error` is not assignable to regular go `error`