### PR TITLE
feat(dunning): Add payment_overdue to invoice

### DIFF
--- a/invoice.go
+++ b/invoice.go
@@ -149,6 +149,7 @@ type Invoice struct {
 	IssuingDate          string    `json:"issuing_date,omitempty"`
 	PaymentDisputeLostAt time.Time `json:"payment_dispute_lost_at,omitempty"`
 	PaymentDueDate       string    `json:"payment_due_date,omitempty"`
+	PaymentOverdue       bool      `json:"payment_overdue,omitempty"`
 
 	InvoiceType   InvoiceType          `json:"invoice_type,omitempty"`
 	Status        InvoiceStatus        `json:"status,omitempty"`

--- a/invoice.go
+++ b/invoice.go
@@ -102,6 +102,7 @@ type InvoiceListInput struct {
 	ExternalCustomerID string               `json:"external_customer_id,omitempty"`
 	Status             InvoiceStatus        `json:"status,omitempty"`
 	PaymentStatus      InvoicePaymentStatus `json:"payment_status,omitempty"`
+	PaymentOverdue     bool                 `json:"payment_overdue,omitempty"`
 }
 
 type InvoiceCreditItem struct {


### PR DESCRIPTION
## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/regroup-invoices-to-generate-one-payment-intent

## Context

We want to be able to group invoices to generate one payment.
Today we don't track payment terms and do not mention whether a payment or an invoice is overdue.

## Description

The goal of this PR is to add:

- `payment_overdue`

to `invoice`