### PR TITLE
fix(inputs): Fix string encoding as paramters

### DIFF
--- a/gross_revenue.go
+++ b/gross_revenue.go
@@ -10,8 +10,8 @@ type GrossRevenueRequest struct {
 }
 
 type GrossRevenueListInput struct {
-	AmountCurrency     string `json:"currency,omitempty,string"`
-	ExternalCustomerId string `json:"external_customer_id,omitempty,string"`
+	AmountCurrency     string `json:"currency,omitempty"`
+	ExternalCustomerId string `json:"external_customer_id,omitempty"`
 	Months             int    `json:"months,omitempty,string"`
 }
 

--- a/invoice_collection.go
+++ b/invoice_collection.go
@@ -12,7 +12,7 @@ type InvoiceCollectionRequest struct {
 }
 
 type InvoiceCollectionListInput struct {
-	AmountCurrency string `json:"currency,omitempty,string"`
+	AmountCurrency string `json:"currency,omitempty"`
 	Months         int    `json:"months,omitempty,string"`
 }
 

--- a/invoiced_usage.go
+++ b/invoiced_usage.go
@@ -10,7 +10,7 @@ type InvoicedUsageRequest struct {
 }
 
 type InvoicedUsageListInput struct {
-	AmountCurrency string `json:"currency,omitempty,string"`
+	AmountCurrency string `json:"currency,omitempty"`
 	Months         int    `json:"months,omitempty,string"`
 }
 

--- a/mrr.go
+++ b/mrr.go
@@ -10,7 +10,7 @@ type MrrRequest struct {
 }
 
 type MrrListInput struct {
-	AmountCurrency string `json:"currency,omitempty,string"`
+	AmountCurrency string `json:"currency,omitempty"`
 	Months         int    `json:"months,omitempty,string"`
 }
 

--- a/wallet.go
+++ b/wallet.go
@@ -63,7 +63,7 @@ type WalletInput struct {
 type WalletListInput struct {
 	PerPage            int    `json:"per_page,omitempty,string"`
 	Page               int    `json:"page,omitempty,string"`
-	ExternalCustomerID string `json:"external_customer_id,omitempty,string"`
+	ExternalCustomerID string `json:"external_customer_id,omitempty"`
 }
 
 type WalletResult struct {


### PR DESCRIPTION
In Go, when a string attribute is explicitly noted at `string` for serialization, outer quotes are added `"`. I have no idea if it's intentional, but probably.

Typically, the `WalletListInput.ExternalCustomerID` will result in this URL:

```
/api/v1/wallets?external_customer_id=%22julien%22
```

Hence, the external_id we look for the DB is `"julien"`, not `julien`.

```sql
SELECT
	"customers".*
FROM
	"customers"
WHERE
	"customers"."deleted_at" IS NULL
	AND "customers"."organization_id" = "external_id"
	AND "customers"."external_id" = "\"julien\""
LIMIT 1
```


### Example

```go
package main

import (
	"encoding/json"
	"fmt"
)

type Interesting struct {
	Quoted    string `json:"quoted,omitempty,string"`
	NotQuoted string `json:"not_quoted,omitempty"`
}

func main() {
	strings := Interesting{"lago", "lago"}
	fmt.Println(strings)
	fmt.Println()

	jsonStr, _ := json.Marshal(strings)
	fmt.Println(string(jsonStr))
	fmt.Println()

	asMap := make(map[string]string)
	json.Unmarshal(jsonStr, &asMap)
	fmt.Println(asMap)
}
```

```
$ go run main.go
{lago lago}

{"quoted":"\"lago\"","not_quoted":"lago"}

map[not_quoted:lago quoted:"lago"]
```
