### PR TITLE
feat(ProgressiveBilling): Expose Usage Threshold fields

### DIFF
--- a/invoice.go
+++ b/invoice.go
@@ -33,7 +33,9 @@ const (
 )
 
 const (
-	InvoiceCreditItemCredit InvoiceCreditItemType = "coupon"
+	InvoiceCreditItemCoupon     InvoiceCreditItemType = "coupon"
+	InvoiceCreditItemCreditNote InvoiceCreditItemType = "credit_note"
+	InvoiceCreditItemInvoice    InvoiceCreditItemType = "invoice"
 )
 
 type InvoiceRequest struct {
@@ -158,15 +160,16 @@ type Invoice struct {
 
 	Currency Currency `json:"currency,omitempty"`
 
-	FeesAmountCents                   int `json:"fees_amount_cents,omitempty"`
-	TaxesAmountCents                  int `json:"taxes_amount_cents,omitempty"`
-	CouponsAmountCents                int `json:"coupons_amount_cents,omitempty"`
-	CreditNotesAmountCents            int `json:"credit_notes_amount_cents,omitempty"`
-	SubTotalExcludingTaxesAmountCents int `json:"sub_total_excluding_taxes_amount_cents,omitempty"`
-	SubTotalIncludingTaxesAmountCents int `json:"sub_total_including_taxes_amount_cents,omitempty"`
-	TotalAmountCents                  int `json:"total_amount_cents,omitempty"`
-	PrepaidCreditAmountCents          int `json:"prepaid_credit_amount_cents,omitempty"`
-	NetPaymentTerm                    int `json:"net_payment_term,omitempty"`
+	FeesAmountCents                     int `json:"fees_amount_cents,omitempty"`
+	TaxesAmountCents                    int `json:"taxes_amount_cents,omitempty"`
+	CouponsAmountCents                  int `json:"coupons_amount_cents,omitempty"`
+	CreditNotesAmountCents              int `json:"credit_notes_amount_cents,omitempty"`
+	SubTotalExcludingTaxesAmountCents   int `json:"sub_total_excluding_taxes_amount_cents,omitempty"`
+	SubTotalIncludingTaxesAmountCents   int `json:"sub_total_including_taxes_amount_cents,omitempty"`
+	TotalAmountCents                    int `json:"total_amount_cents,omitempty"`
+	PrepaidCreditAmountCents            int `json:"prepaid_credit_amount_cents,omitempty"`
+	ProgressiveBillingCreditAmountCents int `json:"progressive_billing_credit_amount_cents"`
+	NetPaymentTerm                      int `json:"net_payment_term,omitempty"`
 
 	FileURL       string                    `json:"file_url,omitempty"`
 	Metadata      []InvoiceMetadataResponse `json:"metadata,omitempty"`

--- a/invoice.go
+++ b/invoice.go
@@ -178,9 +178,10 @@ type Invoice struct {
 	Customer      *Customer      `json:"customer,omitempty"`
 	Subscriptions []Subscription `json:"subscriptions,omitempty"`
 
-	Fees         []Fee               `json:"fees,omitempty"`
-	Credits      []InvoiceCredit     `json:"credits,omitempty"`
-	AppliedTaxes []InvoiceAppliedTax `json:"applied_taxes,omitempty"`
+	Fees                  []Fee                   `json:"fees,omitempty"`
+	Credits               []InvoiceCredit         `json:"credits,omitempty"`
+	AppliedTaxes          []InvoiceAppliedTax     `json:"applied_taxes,omitempty"`
+	AppliedUsageThreshold []AppliedUsageThreshold `json:"applied_usage_threshold,omitempty"`
 }
 
 type InvoicePaymentUrl struct {

--- a/plan.go
+++ b/plan.go
@@ -68,6 +68,7 @@ type PlanInput struct {
 	Charges            []PlanChargeInput       `json:"charges,omitempty"`
 	MinimumCommitment  *MinimumCommitmentInput `json:"minimum_commitment,omitempty"`
 	TaxCodes           []string                `json:"tax_codes,omitempty"`
+	UsageThresholds    []UsageThresholdInput   `json:"usage_thresholds,omitempty"`
 }
 
 type PlanListInput struct {
@@ -103,7 +104,8 @@ type Plan struct {
 	Charges                  []Charge           `json:"charges,omitempty"`
 	MinimumCommitment        *MinimumCommitment `json:"minimum_commitment"`
 
-	Taxes []Tax `json:"taxes,omitempty"`
+	Taxes           []Tax            `json:"taxes,omitempty"`
+	UsageThresholds []UsageThreshold `json:"usage_thresholds,omitempty"`
 }
 
 func (c *Client) Plan() *PlanRequest {

--- a/subscription.go
+++ b/subscription.go
@@ -66,6 +66,7 @@ type PlanOverridesInput struct {
 	Charges            []ChargeOverridesInput           `json:"charges,omitempty"`
 	MinimumCommitment  *MinimumCommitmentOverridesInput `json:"minimum_commitment"`
 	TaxCodes           []string                         `json:"tax_codes,omitempty"`
+	UsageThresholds    []UsageThreshold                 `json:"usage_thresholds,omitempty"`
 }
 
 type SubscriptionInput struct {

--- a/usage_threshold.go
+++ b/usage_threshold.go
@@ -21,3 +21,9 @@ type UsageThreshold struct {
 	CreatedAt            time.Time `json:"created_at"`
 	UpdatedAt            time.Time `json:"updated_at"`
 }
+
+type AppliedUsageThreshold struct {
+	LifetimeUsageAmountCents int            `json:"lifetime_usage_amount_cents"`
+	CreatedAt                time.Time      `json:"created_at"`
+	UsageThreshold           UsageThreshold `json:"usage_threshold"`
+}

--- a/usage_threshold.go
+++ b/usage_threshold.go
@@ -1,0 +1,23 @@
+package lago
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type UsageThresholdInput struct {
+	LagoId               *uuid.UUID `json:"id,omitempty"`
+	ThresholdDisplayName string     `json:"threshold_display_name,omitempty"`
+	AmountCents          int        `json:"amount_cents"`
+	Recurring            bool       `json:"recurring"`
+}
+
+type UsageThreshold struct {
+	LagoID               uuid.UUID `json:"lago_id"`
+	ThresholdDisplayName string    `json:"threshold_display_name,omitempty"`
+	AmountCents          int       `json:"amount_cents"`
+	Recurring            bool      `json:"recurring"`
+	CreatedAt            time.Time `json:"created_at"`
+	UpdatedAt            time.Time `json:"updated_at"`
+}


### PR DESCRIPTION
## Context

AI companies want their users to pay before the end of a period if usage skyrockets. The problem being that self-serve companies can overuse their API without paying, triggering lots of costs on their side.

## Description

This PR adds:
- New `ProgressiveBillingCreditAmountCents` attribute to `Invoice` struct
- New `InvoiceCreditItemType` values (`invoice` and `credit_note`)
- New `UsageThreshold` and `UsageThresholdInput` structs
- New `UsageThreshold` attribute to `Plan` and `PlanInput` structs