### PR TITLE
feat(customer-type): Add customer type, firstname and lastname to customer

### DIFF
--- a/customer.go
+++ b/customer.go
@@ -33,6 +33,13 @@ const (
 	IntegrationXero     IntegrationType = "xero"
 )
 
+type CustomerType string
+
+const (
+	CompanyCustomerType     CustomerType = "company"
+	IndividualCustomerType	CustomerType = "individual"
+)
+
 type CustomerParams struct {
 	Customer *CustomerInput `json:"customer"`
 }
@@ -78,6 +85,9 @@ type MetadataResponse struct {
 type CustomerInput struct {
 	ExternalID                string                            `json:"external_id,omitempty"`
 	Name                      string                            `json:"name,omitempty"`
+	Firstname                 string                            `json:"first_name,omitempty"`
+	Lastname                  string                            `json:"last_name,omitempty"`
+	CustomerType              CustomerType                      `json:"customer_type,omitempty"`
 	Email                     string                            `json:"email,omitempty"`
 	AddressLine1              string                            `json:"address_line1,omitempty"`
 	AddressLine2              string                            `json:"address_line2,omitempty"`
@@ -218,6 +228,9 @@ type Customer struct {
 	Slug         string    `json:"slug,omitempty"`
 
 	Name                      string                         `json:"name,omitempty"`
+	Firstname                 string                         `json:"first_name,omitempty"`
+	Lastname                  string                         `json:"last_name,omitempty"`
+	CustomerType              string                         `json:"customer_type,omitempty"`
 	Email                     string                         `json:"email,omitempty"`
 	AddressLine1              string                         `json:"address_line1,omitempty"`
 	AddressLine2              string                         `json:"address_line2,omitempty"`


### PR DESCRIPTION
## Context
We currently only create Lago customers as **companies**, but there is a need to support both **companies** and **individuals**. This change is motivated by scenarios where customers may be a mix of B2B and B2C, and where external integrations require handling both **Contacts** and **Companies**.

To address this, we are introducing a new field, `customer_type`, to distinguish whether a customer is a **company** or an **individual**. Existing customers will remain unaffected with `customer_type` set to the default `nil`. 

## Description
This PR adds `firstname`, `lastname` and `customer_type` to the customer object and customer input.