### PR TITLE
feat(DynamicPricing): Expose Event#precise_total_amount_cents

### DIFF
--- a/charge.go
+++ b/charge.go
@@ -15,6 +15,7 @@ const (
 	PackageChargeModel             ChargeModel = "package"
 	PercentageChargeModel          ChargeModel = "percentage"
 	VolumeChargeModel              ChargeModel = "volume"
+	DynamicChargeModel             ChargeModel = "dynamic"
 )
 
 type ChargeFilter struct {

--- a/event.go
+++ b/event.go
@@ -21,11 +21,12 @@ type BatchEventParams struct {
 }
 
 type EventInput struct {
-	TransactionID          string                 `json:"transaction_id,omitempty"`
-	ExternalSubscriptionID string                 `json:"external_subscription_id,omitempty"`
-	Code                   string                 `json:"code,omitempty"`
-	Timestamp              string                 `json:"timestamp,omitempty"`
-	Properties             map[string]interface{} `json:"properties,omitempty"`
+	TransactionID           string                 `json:"transaction_id,omitempty"`
+	ExternalSubscriptionID  string                 `json:"external_subscription_id,omitempty"`
+	Code                    string                 `json:"code,omitempty"`
+	Timestamp               string                 `json:"timestamp,omitempty"`
+	PreciseTotalAmountCents string                 `json:"precise_total_amount_cents,omitempty"`
+	Properties              map[string]interface{} `json:"properties,omitempty"`
 }
 
 type EventEstimateFeesParams struct {
@@ -47,15 +48,16 @@ type EventResult struct {
 }
 
 type Event struct {
-	LagoID                 uuid.UUID              `json:"lago_id"`
-	TransactionID          string                 `json:"transaction_id"`
-	LagoCustomerID         *uuid.UUID             `json:"lago_customer_id,omitempty"`
-	Code                   string                 `json:"code,omitempty"`
-	Timestamp              time.Time              `json:"timestamp"`
-	Properties             map[string]interface{} `json:"properties,omitempty"`
-	LagoSubscriptionID     *uuid.UUID             `json:"lago_subscription_id,omitempty"`
-	ExternalSubscriptionID string                 `json:"external_subscription_id,omitempty"`
-	CreatedAt              time.Time              `json:"created_at"`
+	LagoID                  uuid.UUID              `json:"lago_id"`
+	TransactionID           string                 `json:"transaction_id"`
+	LagoCustomerID          *uuid.UUID             `json:"lago_customer_id,omitempty"`
+	Code                    string                 `json:"code,omitempty"`
+	Timestamp               time.Time              `json:"timestamp"`
+	PreciseTotalAmountCents string                 `json:"precise_total_amount_cents,omitempty"`
+	Properties              map[string]interface{} `json:"properties,omitempty"`
+	LagoSubscriptionID      *uuid.UUID             `json:"lago_subscription_id,omitempty"`
+	ExternalSubscriptionID  string                 `json:"external_subscription_id,omitempty"`
+	CreatedAt               time.Time              `json:"created_at"`
 }
 
 func (c *Client) Event() *EventRequest {


### PR DESCRIPTION
## Context

AI, CPaaS and Fintech customers can apply a price to a unit that fluctuates over time. Currently Lago does not support this usecase.

## Description

This PR is related to https://github.com/getlago/lago-api/pull/2610.
It documents the new `precise_total_amount_cents` in input and result payloads on `POST /api/v1/events` and `POST /api/v1/batch_events`