### PR TITLE
feat(felixible aggregation): Expose expression in API

### DIFF
--- a/billable_metric.go
+++ b/billable_metric.go
@@ -40,6 +40,7 @@ type BillableMetricInput struct {
 	Description      string                 `json:"description,omitempty"`
 	AggregationType  AggregationType        `json:"aggregation_type,omitempty"`
 	Recurring        bool                   `json:"recurring,omitempty"`
+	Expression       string                 `json:"expression,omitempty"`
 	FieldName        string                 `json:"field_name"`
 	WeightedInterval WeightedInterval       `json:"weighted_interval,omitempty"`
 	Filters          []BillableMetricFilter `json:"filters,omitempty"`
@@ -68,6 +69,7 @@ type BillableMetric struct {
 	Description              string                 `json:"description,omitempty"`
 	Recurring                bool                   `json:"recurring,omitempty"`
 	AggregationType          AggregationType        `json:"aggregation_type,omitempty"`
+	Expression               string                 `json:"expression,omitempty"`
 	FieldName                string                 `json:"field_name"`
 	CreatedAt                time.Time              `json:"created_at,omitempty"`
 	WeightedInterval         *WeightedInterval      `json:"weighted_interval,omitempty"`

--- a/billable_metric.go
+++ b/billable_metric.go
@@ -79,6 +79,25 @@ type BillableMetric struct {
 	PlansCount               int                    `json:"plans_count,omitempty"`
 }
 
+type BillableMetricEveluateExpressionEvent struct {
+	Code       string                 `json:"code,omitempty"`
+	Timestamp  string                 `json:"timestamp,omitempty"`
+	Properties map[string]interface{} `json:"properties,omitempty"`
+}
+
+type BillableMetricEvaluateExpressionInput struct {
+	Expression string                                `json:"expression"`
+	Event      BillableMetricEveluateExpressionEvent `json:"event"`
+}
+
+type BillableMetricEvaluateExpressionResultValue struct {
+	Value string `json:"value,omitempty"`
+}
+
+type BillableMetricEvaluateExpressionResult struct {
+	ExpressionResult BillableMetricEvaluateExpressionResultValue `json:"expression_result,omitempty"`
+}
+
 func (c *Client) BillableMetric() *BillableMetricRequest {
 	return &BillableMetricRequest{
 		client: c,
@@ -199,4 +218,24 @@ func (bmr *BillableMetricRequest) Delete(ctx context.Context, billableMetricCode
 	}
 
 	return billableMetricResult.BillableMetric, nil
+}
+
+func (bmr *BillableMetricRequest) EvaluateExpression(ctx context.Context, evaluateExpressingInput *BillableMetricEvaluateExpressionInput) (*BillableMetricEvaluateExpressionResultValue, *Error) {
+	clientRequest := &ClientRequest{
+		Path:   "billable_metrics/evaluate_expression",
+		Result: &BillableMetricEvaluateExpressionResult{},
+		Body:   evaluateExpressingInput,
+	}
+
+	result, err := bmr.client.Post(ctx, clientRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	evaluateExpressionResult, ok := result.(*BillableMetricEvaluateExpressionResult)
+	if !ok {
+		return nil, &ErrorTypeAssert
+	}
+
+	return &evaluateExpressionResult.ExpressionResult, nil
 }


### PR DESCRIPTION
This PR is related to https://github.com/getlago/lago-api/pull/2704

It exposes:
- The new `expression` field on billable metric input and output payloads
- The new `POST /api/v1/billable_metrics/evaluate_expression` api end-point