### PR TITLE
feat(billable_metric): Expose rounding attributes

### DIFF
--- a/billable_metric.go
+++ b/billable_metric.go
@@ -24,6 +24,14 @@ const (
 	WeightedSumAggregation    AggregationType = "weighted_sum_agg"
 )
 
+type RoundingFunction string
+
+const (
+	RoundRoundingFunction RoundingFunction = "round"
+	CeilRoundingFunction  RoundingFunction = "ceil"
+	FloorRoundingFunction RoundingFunction = "floor"
+)
+
 type WeightedInterval string
 
 const (
@@ -35,15 +43,17 @@ type BillableMetricParams struct {
 }
 
 type BillableMetricInput struct {
-	Name             string                 `json:"name,omitempty"`
-	Code             string                 `json:"code,omitempty"`
-	Description      string                 `json:"description,omitempty"`
-	AggregationType  AggregationType        `json:"aggregation_type,omitempty"`
-	Recurring        bool                   `json:"recurring,omitempty"`
-	Expression       string                 `json:"expression,omitempty"`
-	FieldName        string                 `json:"field_name"`
-	WeightedInterval WeightedInterval       `json:"weighted_interval,omitempty"`
-	Filters          []BillableMetricFilter `json:"filters,omitempty"`
+	Name              string                 `json:"name,omitempty"`
+	Code              string                 `json:"code,omitempty"`
+	Description       string                 `json:"description,omitempty"`
+	AggregationType   AggregationType        `json:"aggregation_type,omitempty"`
+	Recurring         bool                   `json:"recurring,omitempty"`
+	RoundingFunction  *RoundingFunction      `json:"rounding_function,omitempty"`
+	RoundingPrecision *int                   `json:"rounding_precision,omitempty"`
+	Expression        string                 `json:"expression,omitempty"`
+	FieldName         string                 `json:"field_name"`
+	WeightedInterval  WeightedInterval       `json:"weighted_interval,omitempty"`
+	Filters           []BillableMetricFilter `json:"filters,omitempty"`
 }
 
 type BillableMetricListInput struct {
@@ -68,6 +78,8 @@ type BillableMetric struct {
 	Code                     string                 `json:"code,omitempty"`
 	Description              string                 `json:"description,omitempty"`
 	Recurring                bool                   `json:"recurring,omitempty"`
+	RoundingFunction         *RoundingFunction      `json:"rounding_function,omitempty"`
+	RoundingPrecision        *int                   `json:"rounding_precision,omitempty"`
 	AggregationType          AggregationType        `json:"aggregation_type,omitempty"`
 	Expression               string                 `json:"expression,omitempty"`
 	FieldName                string                 `json:"field_name"`


### PR DESCRIPTION
## Context

This PR is related to https://github.com/getlago/lago-api/pull/2764

In addition to the [flexible aggregation](https://github.com/119ef63110d2803db639f0db37a3b135?pvs=25), some customers wants to round the output of the aggregation.

## Description

This PR exposes `rounding_function` and `rounding_precision` to the billable_metrics client.