### PR TITLE
misc: Remove *_count fields

### DIFF
--- a/billable_metric.go
+++ b/billable_metric.go
@@ -73,22 +73,19 @@ type BillableMetricFilter struct {
 }
 
 type BillableMetric struct {
-	LagoID                   uuid.UUID              `json:"lago_id"`
-	Name                     string                 `json:"name,omitempty"`
-	Code                     string                 `json:"code,omitempty"`
-	Description              string                 `json:"description,omitempty"`
-	Recurring                bool                   `json:"recurring,omitempty"`
-	RoundingFunction         *RoundingFunction      `json:"rounding_function,omitempty"`
-	RoundingPrecision        *int                   `json:"rounding_precision,omitempty"`
-	AggregationType          AggregationType        `json:"aggregation_type,omitempty"`
-	Expression               string                 `json:"expression,omitempty"`
-	FieldName                string                 `json:"field_name"`
-	CreatedAt                time.Time              `json:"created_at,omitempty"`
-	WeightedInterval         *WeightedInterval      `json:"weighted_interval,omitempty"`
-	Filters                  []BillableMetricFilter `json:"filters,omitempty"`
-	ActiveSubscriptionsCount int                    `json:"active_subscriptions_count,omitempty"`
-	DraftInvoicesCount       int                    `json:"draft_invoices_count,omitempty"`
-	PlansCount               int                    `json:"plans_count,omitempty"`
+	LagoID            uuid.UUID              `json:"lago_id"`
+	Name              string                 `json:"name,omitempty"`
+	Code              string                 `json:"code,omitempty"`
+	Description       string                 `json:"description,omitempty"`
+	Recurring         bool                   `json:"recurring,omitempty"`
+	RoundingFunction  *RoundingFunction      `json:"rounding_function,omitempty"`
+	RoundingPrecision *int                   `json:"rounding_precision,omitempty"`
+	AggregationType   AggregationType        `json:"aggregation_type,omitempty"`
+	Expression        string                 `json:"expression,omitempty"`
+	FieldName         string                 `json:"field_name"`
+	CreatedAt         time.Time              `json:"created_at,omitempty"`
+	WeightedInterval  *WeightedInterval      `json:"weighted_interval,omitempty"`
+	Filters           []BillableMetricFilter `json:"filters,omitempty"`
 }
 
 type BillableMetricEveluateExpressionEvent struct {

--- a/plan.go
+++ b/plan.go
@@ -90,20 +90,18 @@ type MinimumCommitment struct {
 }
 
 type Plan struct {
-	LagoID                   uuid.UUID          `json:"lago_id"`
-	Name                     string             `json:"name,omitempty"`
-	InvoiceDisplayName       string             `json:"invoice_display_name,omitempty"`
-	Code                     string             `json:"code,omitempty"`
-	Interval                 PlanInterval       `json:"interval,omitempty"`
-	Description              string             `json:"description,omitempty"`
-	AmountCents              int                `json:"amount_cents,omitempty"`
-	AmountCurrency           Currency           `json:"amount_currency,omitempty"`
-	PayInAdvance             bool               `json:"pay_in_advance,omitempty"`
-	BillChargeMonthly        bool               `json:"bill_charge_monthly,omitempty"`
-	ActiveSubscriptionsCount int                `json:"active_subscriptions_count,omitempty"`
-	DraftInvoicesCount       int                `json:"draft_invoices_count,omitempty"`
-	Charges                  []Charge           `json:"charges,omitempty"`
-	MinimumCommitment        *MinimumCommitment `json:"minimum_commitment"`
+	LagoID             uuid.UUID          `json:"lago_id"`
+	Name               string             `json:"name,omitempty"`
+	InvoiceDisplayName string             `json:"invoice_display_name,omitempty"`
+	Code               string             `json:"code,omitempty"`
+	Interval           PlanInterval       `json:"interval,omitempty"`
+	Description        string             `json:"description,omitempty"`
+	AmountCents        int                `json:"amount_cents,omitempty"`
+	AmountCurrency     Currency           `json:"amount_currency,omitempty"`
+	PayInAdvance       bool               `json:"pay_in_advance,omitempty"`
+	BillChargeMonthly  bool               `json:"bill_charge_monthly,omitempty"`
+	Charges            []Charge           `json:"charges,omitempty"`
+	MinimumCommitment  *MinimumCommitment `json:"minimum_commitment"`
 
 	Taxes           []Tax            `json:"taxes,omitempty"`
 	UsageThresholds []UsageThreshold `json:"usage_thresholds,omitempty"`

--- a/tax.go
+++ b/tax.go
@@ -44,10 +44,6 @@ type Tax struct {
 	Code                  string    `json:"code,omitempty"`
 	Rate                  float32   `json:"rate,omitempty"`
 	Description           string    `json:"description,omitempty"`
-	AddOnsCount           int       `json:"add_ons_count,omitempty"`
-	CustomersCount        int       `json:"customers_count,omitempty"`
-	PlansCount            int       `json:"plans_count,omitempty"`
-	ChargesCount          int       `json:"charges_count,omitempty"`
 	AppliedToOrganization bool      `json:"applied_to_organization,omitempty"`
 	CreatedAt             time.Time `json:"created_at,omitempty"`
 }


### PR DESCRIPTION
# Context

The API response are returning a lot of counters. Since the exposed resources can be linked to a lot of objects and can be called a lot, these counters are posing a scalability problem and are slowing down the global performance of the API.

To remediate the situation the decision was made to remove all these fields.

# Changes

This PR removes the following fields:
- BillableMetric
  -  active_subscriptions_count
  - draft_invoices_count
  - plans_count
- Plan
  - active_subscriptions_count
  - draft_invoices_count
- Tax
  - add_ons_count
  - charges_count
  - customers_count
  - plans_count