### PR TITLE
feat: add apply taxes params to current usage

### DIFF
--- a/customer.go
+++ b/customer.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"time"
-
+    "strconv"
 	"github.com/google/uuid"
 )
 
@@ -226,7 +226,7 @@ type CustomerCheckoutUrl struct {
 
 type CustomerUsageInput struct {
 	ExternalSubscriptionID string `json:"external_subscription_id,omitempty"`
-    ApplyTaxes             string `json:"apply_taxes,omitempty"`
+	ApplyTaxes             bool   `json:"apply_taxes,omitempty"`
 }
 
 type CustomerPastUsageInput struct {
@@ -319,14 +319,9 @@ func (cr *CustomerRequest) Update(ctx context.Context, customerInput *CustomerIn
 func (cr *CustomerRequest) CurrentUsage(ctx context.Context, externalCustomerID string, customerUsageInput *CustomerUsageInput) (*CustomerUsage, *Error) {
 	subPath := fmt.Sprintf("%s/%s/%s", "customers", externalCustomerID, "current_usage")
 
-	jsonQueryParams, err := json.Marshal(customerUsageInput)
-	if err != nil {
-		return nil, &Error{Err: err}
-	}
-
-	queryParams := make(map[string]string)
-	if err = json.Unmarshal(jsonQueryParams, &queryParams); err != nil {
-		return nil, &Error{Err: err}
+	queryParams := map[string]string{
+		"external_subscription_id": customerUsageInput.ExternalSubscriptionID,
+		"apply_taxes":              strconv.FormatBool(customerUsageInput.ApplyTaxes),
 	}
 
 	clientRequest := &ClientRequest{

--- a/customer.go
+++ b/customer.go
@@ -226,6 +226,7 @@ type CustomerCheckoutUrl struct {
 
 type CustomerUsageInput struct {
 	ExternalSubscriptionID string `json:"external_subscription_id,omitempty"`
+    ApplyTaxes             string `json:"apply_taxes,omitempty"`
 }
 
 type CustomerPastUsageInput struct {


### PR DESCRIPTION
Updated the current_usage method to accept an optional apply_taxes parameter, defaulting to True. This parameter is included in the query string as a lowercase string ("true" or "false").