### PR TITLE
fix: plan input request of bill charges monthly

### DIFF
--- a/plan.go
+++ b/plan.go
@@ -63,7 +63,7 @@ type PlanInput struct {
 	AmountCents        int                     `json:"amount_cents"`
 	AmountCurrency     Currency                `json:"amount_currency,omitempty"`
 	PayInAdvance       bool                    `json:"pay_in_advance"`
-	BillChargeMonthly  bool                    `json:"bill_charge_monthly"`
+	BillChargesMonthly bool                    `json:"bill_charges_monthly"`
 	TrialPeriod        float32                 `json:"trial_period"`
 	Charges            []PlanChargeInput       `json:"charges,omitempty"`
 	MinimumCommitment  *MinimumCommitmentInput `json:"minimum_commitment,omitempty"`
@@ -99,7 +99,7 @@ type Plan struct {
 	AmountCents        int                `json:"amount_cents,omitempty"`
 	AmountCurrency     Currency           `json:"amount_currency,omitempty"`
 	PayInAdvance       bool               `json:"pay_in_advance,omitempty"`
-	BillChargeMonthly  bool               `json:"bill_charge_monthly,omitempty"`
+	BillChargesMonthly bool               `json:"bill_charges_monthly,omitempty"`
 	Charges            []Charge           `json:"charges,omitempty"`
 	MinimumCommitment  *MinimumCommitment `json:"minimum_commitment"`
 


### PR DESCRIPTION
## PR Description

**Describe the bug:**

The `PlanInput` struct's `bill_charge_monthly` field uses the singular form, while the Lago API expects the plural form `bill_charges_monthly`, as documented in [https://docs.getlago.com/api-reference/plans/create#body-plan-bill-charges-monthly](https://docs.getlago.com/api-reference/plans/create#body-plan-bill-charges-monthly) and the list plan endpoint. This discrepancy causes issues when creating or retrieving plans.

**Expected behavior:**

The `PlanInput` struct should use the plural form `bill_charges_monthly` to align with the Lago API.

**- Actual:**

```go
BillChargeMonthly bool `json:"bill_charge_monthly"`
```

**- Expected:**

```go
BillChargesMonthly bool `json:"bill_charges_monthly"`
```

**Changes:**

* Renamed the `BillChargeMonthly` field in the `PlanInput` struct to `BillChargesMonthly`.
