### PR TITLE
fix: customer past usage period count json type

### DIFF
--- a/customer.go
+++ b/customer.go
@@ -246,7 +246,7 @@ type CustomerUsageInput struct {
 type CustomerPastUsageInput struct {
 	ExternalSubscriptionID string `json:"external_subscription_id"`
 	BillableMetricCode     string `json:"billable_metric_code,omitempty"`
-	PeriodsCount           int    `json:"periods_count,omitempty"`
+	PeriodsCount           int    `json:"periods_count,omitempty,string"`
 }
 
 type Customer struct {


### PR DESCRIPTION
Currently, setting `PeriodsCount` in the `PastUsage` method throws a marshaling error because it's typed as int in JSON.

```
json: cannot unmarshal number into Go value of type strin
```

Added the `,string` json tag which should turn the `PeriodsCount` into a string so that it can be Unmarshalled into `map[string]string`.
