### PR TITLE
fix: add meta pagination payment receipt, payment request

### DIFF
--- a/payment_receipt.go
+++ b/payment_receipt.go
@@ -16,6 +16,7 @@ type PaymentReceiptRequest struct {
 type PaymentReceiptResult struct {
 	PaymentReceipt  *PaymentReceipt  `json:"payment_receipt,omitempty"`
 	PaymentReceipts []PaymentReceipt `json:"payment_receipts,omitempty"`
+	Meta            Metadata         `json:"meta,omitempty"`
 }
 
 type PaymentReceiptListInput struct {
@@ -26,10 +27,10 @@ type PaymentReceiptListInput struct {
 }
 
 type PaymentReceipt struct {
-	LagoID         uuid.UUID `json:"lago_id,omitempty"`
-	Number         string    `json:"number,omitempty"`
-	CreatedAt      time.Time `json:"created_at,omitempty"`
-	Payment 	   *Payment `json:"payment,omitempty"`
+	LagoID    uuid.UUID `json:"lago_id,omitempty"`
+	Number    string    `json:"number,omitempty"`
+	CreatedAt time.Time `json:"created_at,omitempty"`
+	Payment   *Payment  `json:"payment,omitempty"`
 }
 
 func (c *Client) PaymentReceipt() *PaymentReceiptRequest {

--- a/payment_request.go
+++ b/payment_request.go
@@ -15,6 +15,7 @@ type PaymentRequestRequest struct {
 type PaymentRequestResult struct {
 	PaymentRequest  *PaymentRequest  `json:"payment_request,omitempty"`
 	PaymentRequests []PaymentRequest `json:"payment_requests,omitempty"`
+	Meta            Metadata         `json:"meta,omitempty"`
 }
 
 type PaymentRequestListInput struct {


### PR DESCRIPTION
Adds the missing Meta pagination to payment requests and payment receipts 

https://docs.getlago.com/api-reference/payment-receipts/get-all
https://docs.getlago.com/api-reference/payment-requests/get-all