### PR TITLE
fix(invoices):retry_payment does not return an invoice

### DIFF
--- a/invoice.go
+++ b/invoice.go
@@ -470,6 +470,7 @@ func (ir *InvoiceRequest) LoseDispute(ctx context.Context, invoiceID string) (*I
 	return nil, nil
 }
 
+// We have Invoice as a possible return to be consitent with other endpoints, but no Invoice will be returned.
 func (ir *InvoiceRequest) RetryPayment(ctx context.Context, invoiceID string) (*Invoice, *Error) {
 	subPath := fmt.Sprintf("%s/%s/%s", "invoices", invoiceID, "retry_payment")
 	clientRequest := &ClientRequest{
@@ -477,18 +478,10 @@ func (ir *InvoiceRequest) RetryPayment(ctx context.Context, invoiceID string) (*
 		Result: &InvoiceResult{},
 	}
 
-	result, err := ir.client.PostWithoutBody(ctx, clientRequest)
+	// We don't return an invoice here due to async retry payment processing
+	_, err := ir.client.PostWithoutBody(ctx, clientRequest)
 	if err != nil {
 		return nil, err
-	}
-
-	if result != nil {
-		invoiceResult, ok := result.(*InvoiceResult)
-		if !ok {
-			return nil, &ErrorTypeAssert
-		}
-
-		return invoiceResult.Invoice, nil
 	}
 
 	return nil, nil


### PR DESCRIPTION
The [`retry_payment` endpoint on api](https://github.com/getlago/lago-api/blob/bcdea346d54c6aa6c648c35ff08095aa7e2dee39/app/controllers/api/v1/invoices_controller.rb#L156-L164) **does not return** an invoice object. 

The explanation for this is due [the payment for that invoice will be retried asynchronously](https://github.com/getlago/lago-api/blob/fe159417fc15ae48b4eab94641a32a30ef39ac11/app/services/invoices/payments/retry_service.rb#L32) and the invoice information may change. With that in mind, we may be returning an out-dated record, so is preferred to return nothing. 

We kept the method signature with Invoice as an expected return to be consistent with other endpoints and to not add a breaking change right now.