### PR TITLE
chore(lint): Run `go fmt` on all Go files and add `gofmt` to CI

### DIFF
--- a/.github/workflows/gofmt.yml
+++ b/.github/workflows/gofmt.yml
@@ -1,0 +1,31 @@
+name: gofmt
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - main
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  gofmt:
+    name: Go fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+          # The builtin cache feature ensures that installing golangci-lint
+          # is consistently fast.
+          cache: true
+          cache-dependency-path: go.sum
+      - name: check-gofmt
+        run: |
+          if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then
+            echo "The following files are not formatted:"
+            gofmt -s -l .
+            echo "Please run 'go fmt ./...' to format the code."
+            exit 1
+          fi

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,7 +12,7 @@ permissions:
   # pull-requests: read
 jobs:
   golangci:
-    name: lint
+    name: golangci-lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/billing_entity.go
+++ b/billing_entity.go
@@ -11,7 +11,7 @@ import (
 type BillingEntityDocumentNumbering string
 
 const (
-	BillingEntityDocumentNumberingPerCustomer      BillingEntityDocumentNumbering = "per_customer"
+	BillingEntityDocumentNumberingPerCustomer     BillingEntityDocumentNumbering = "per_customer"
 	BillingEntityDocumentNumberingPerBillingEntity BillingEntityDocumentNumbering = "per_billing_entity"
 )
 
@@ -28,9 +28,9 @@ type BillingEntityUpdateParams struct {
 }
 
 type BillingEntityResult struct {
-	BillingEntity   *BillingEntity  `json:"billing_entity,omitempty"`
-	BillingEntities []BillingEntity `json:"billing_entities,omitempty"`
-	Meta            Metadata        `json:"meta,omitempty"`
+	BillingEntity   *BillingEntity   `json:"billing_entity,omitempty"`
+	BillingEntities []BillingEntity  `json:"billing_entities,omitempty"`
+	Meta            Metadata         `json:"meta,omitempty"`
 }
 
 type BillingEntityBillingConfiguration struct {
@@ -66,59 +66,59 @@ type BillingEntity struct {
 	EuTaxManagement           bool                           `json:"eu_tax_management,omitempty"`
 	LogoURL                   string                         `json:"logo_url,omitempty"`
 	InvoiceFooter             string                         `json:"invoice_footer,omitempty"`
-	InvoiceGracePeriod        int                            `json:"invoice_grace_period,omitempty"`
-	DocumentLocale            string                         `json:"document_locale,omitempty"`
-	Taxes                     []Tax                          `json:"taxes,omitempty"`
+    InvoiceGracePeriod        int                            `json:"invoice_grace_period,omitempty"`
+    DocumentLocale            string                         `json:"document_locale,omitempty"`
+	Taxes 					  []Tax 					     `json:"taxes,omitempty"`
 }
 
-type BillingEntityCreateInput struct {
-	Name                      string                            `json:"name,omitempty"`
-	Code                      string                            `json:"code,omitempty"`
-	Email                     string                            `json:"email,omitempty"`
-	AddressLine1              string                            `json:"address_line1,omitempty"`
-	AddressLine2              string                            `json:"address_line2,omitempty"`
-	City                      string                            `json:"city,omitempty"`
-	Zipcode                   string                            `json:"zipcode,omitempty"`
-	State                     string                            `json:"state,omitempty"`
-	Country                   string                            `json:"country,omitempty"`
-	DefaultCurrency           Currency                          `json:"default_currency,omitempty"`
-	LegalName                 string                            `json:"legal_name,omitempty"`
-	LegalNumber               string                            `json:"legal_number,omitempty"`
-	DocumentNumbering         BillingEntityDocumentNumbering    `json:"document_numbering,omitempty"`
-	DocumentNumberPrefix      string                            `json:"document_number_prefix,omitempty"`
-	NetPaymentTerm            int                               `json:"net_payment_term,omitempty"`
-	Timezone                  string                            `json:"timezone,omitempty"`
-	EmailSettings             []string                          `json:"email_settings,omitempty"`
-	TaxIdentificationNumber   string                            `json:"tax_identification_number,omitempty"`
-	FinalizeZeroAmountInvoice bool                              `json:"finalize_zero_amount_invoice,omitempty"`
-	EuTaxManagement           bool                              `json:"eu_tax_management,omitempty"`
-	BillingConfiguration      BillingEntityBillingConfiguration `json:"billing_configuration,omitempty"`
-	LogoBase64                string                            `json:"logo,omitempty"`
+type BillingEntityCreateInput struct {			
+	Name                     	string                         			`json:"name,omitempty"`
+	Code                     	string                         			`json:"code,omitempty"`
+	Email                    	string                         			`json:"email,omitempty"`
+	AddressLine1             	string                         			`json:"address_line1,omitempty"`
+	AddressLine2             	string                         			`json:"address_line2,omitempty"`
+	City                     	string                         			`json:"city,omitempty"`
+	Zipcode                  	string                         			`json:"zipcode,omitempty"`
+	State                    	string                         			`json:"state,omitempty"`
+	Country                  	string                         			`json:"country,omitempty"`
+	DefaultCurrency          	Currency                       			`json:"default_currency,omitempty"`
+	LegalName                	string                         			`json:"legal_name,omitempty"`
+	LegalNumber              	string                         			`json:"legal_number,omitempty"`
+	DocumentNumbering        	BillingEntityDocumentNumbering 			`json:"document_numbering,omitempty"`
+	DocumentNumberPrefix     	string                         			`json:"document_number_prefix,omitempty"`
+	NetPaymentTerm           	int                            			`json:"net_payment_term,omitempty"`
+	Timezone                 	string                         			`json:"timezone,omitempty"`
+	EmailSettings            	[]string                       			`json:"email_settings,omitempty"`
+	TaxIdentificationNumber  	string                         			`json:"tax_identification_number,omitempty"`
+	FinalizeZeroAmountInvoice 	bool                           			`json:"finalize_zero_amount_invoice,omitempty"`
+	EuTaxManagement          	bool                           			`json:"eu_tax_management,omitempty"`
+	BillingConfiguration 	  	BillingEntityBillingConfiguration 		`json:"billing_configuration,omitempty"`
+	LogoBase64                	string                         			`json:"logo,omitempty"`
 }
 
 type BillingEntityUpdateInput struct {
-	Name                      string                            `json:"name,omitempty"`
-	Email                     string                            `json:"email,omitempty"`
-	AddressLine1              string                            `json:"address_line1,omitempty"`
-	AddressLine2              string                            `json:"address_line2,omitempty"`
-	City                      string                            `json:"city,omitempty"`
-	Zipcode                   string                            `json:"zipcode,omitempty"`
-	State                     string                            `json:"state,omitempty"`
-	Country                   string                            `json:"country,omitempty"`
-	DefaultCurrency           Currency                          `json:"default_currency,omitempty"`
-	LegalName                 string                            `json:"legal_name,omitempty"`
-	LegalNumber               string                            `json:"legal_number,omitempty"`
-	DocumentNumbering         BillingEntityDocumentNumbering    `json:"document_numbering,omitempty"`
-	DocumentNumberPrefix      string                            `json:"document_number_prefix,omitempty"`
-	NetPaymentTerm            int                               `json:"net_payment_term,omitempty"`
-	Timezone                  string                            `json:"timezone,omitempty"`
-	EmailSettings             []string                          `json:"email_settings,omitempty"`
-	TaxIdentificationNumber   string                            `json:"tax_identification_number,omitempty"`
-	FinalizeZeroAmountInvoice bool                              `json:"finalize_zero_amount_invoice,omitempty"`
-	EuTaxManagement           bool                              `json:"eu_tax_management,omitempty"`
-	BillingConfiguration      BillingEntityBillingConfiguration `json:"billing_configuration,omitempty"`
-	LogoBase64                string                            `json:"logo,omitempty"`
-	TaxCodes                  []string                          `json:"tax_codes,omitempty"`
+	Name                     	string                         			`json:"name,omitempty"`
+	Email                    	string                         			`json:"email,omitempty"`
+	AddressLine1             	string                         			`json:"address_line1,omitempty"`
+	AddressLine2             	string                         			`json:"address_line2,omitempty"`
+	City                     	string                         			`json:"city,omitempty"`
+	Zipcode                  	string                         			`json:"zipcode,omitempty"`
+	State                    	string                         			`json:"state,omitempty"`
+	Country                  	string                         			`json:"country,omitempty"`
+	DefaultCurrency          	Currency                       			`json:"default_currency,omitempty"`
+	LegalName                	string                         			`json:"legal_name,omitempty"`
+	LegalNumber              	string                         			`json:"legal_number,omitempty"`
+	DocumentNumbering        	BillingEntityDocumentNumbering 			`json:"document_numbering,omitempty"`
+	DocumentNumberPrefix     	string                         			`json:"document_number_prefix,omitempty"`
+	NetPaymentTerm           	int                            			`json:"net_payment_term,omitempty"`
+	Timezone                 	string                         			`json:"timezone,omitempty"`
+	EmailSettings            	[]string                       			`json:"email_settings,omitempty"`
+	TaxIdentificationNumber  	string                         			`json:"tax_identification_number,omitempty"`
+	FinalizeZeroAmountInvoice 	bool                           			`json:"finalize_zero_amount_invoice,omitempty"`
+	EuTaxManagement          	bool                           			`json:"eu_tax_management,omitempty"`
+	BillingConfiguration 	  	BillingEntityBillingConfiguration 		`json:"billing_configuration,omitempty"`
+	LogoBase64                	string                         			`json:"logo,omitempty"`
+	TaxCodes                    []string                       			`json:"tax_codes,omitempty"`
 }
 
 func (c *Client) BillingEntity() *BillingEntityRequest {

--- a/billing_entity.go
+++ b/billing_entity.go
@@ -11,7 +11,7 @@ import (
 type BillingEntityDocumentNumbering string
 
 const (
-	BillingEntityDocumentNumberingPerCustomer     BillingEntityDocumentNumbering = "per_customer"
+	BillingEntityDocumentNumberingPerCustomer      BillingEntityDocumentNumbering = "per_customer"
 	BillingEntityDocumentNumberingPerBillingEntity BillingEntityDocumentNumbering = "per_billing_entity"
 )
 
@@ -28,9 +28,9 @@ type BillingEntityUpdateParams struct {
 }
 
 type BillingEntityResult struct {
-	BillingEntity   *BillingEntity   `json:"billing_entity,omitempty"`
-	BillingEntities []BillingEntity  `json:"billing_entities,omitempty"`
-	Meta            Metadata         `json:"meta,omitempty"`
+	BillingEntity   *BillingEntity  `json:"billing_entity,omitempty"`
+	BillingEntities []BillingEntity `json:"billing_entities,omitempty"`
+	Meta            Metadata        `json:"meta,omitempty"`
 }
 
 type BillingEntityBillingConfiguration struct {
@@ -66,59 +66,59 @@ type BillingEntity struct {
 	EuTaxManagement           bool                           `json:"eu_tax_management,omitempty"`
 	LogoURL                   string                         `json:"logo_url,omitempty"`
 	InvoiceFooter             string                         `json:"invoice_footer,omitempty"`
-    InvoiceGracePeriod        int                            `json:"invoice_grace_period,omitempty"`
-    DocumentLocale            string                         `json:"document_locale,omitempty"`
-	Taxes 					  []Tax 					     `json:"taxes,omitempty"`
+	InvoiceGracePeriod        int                            `json:"invoice_grace_period,omitempty"`
+	DocumentLocale            string                         `json:"document_locale,omitempty"`
+	Taxes                     []Tax                          `json:"taxes,omitempty"`
 }
 
-type BillingEntityCreateInput struct {			
-	Name                     	string                         			`json:"name,omitempty"`
-	Code                     	string                         			`json:"code,omitempty"`
-	Email                    	string                         			`json:"email,omitempty"`
-	AddressLine1             	string                         			`json:"address_line1,omitempty"`
-	AddressLine2             	string                         			`json:"address_line2,omitempty"`
-	City                     	string                         			`json:"city,omitempty"`
-	Zipcode                  	string                         			`json:"zipcode,omitempty"`
-	State                    	string                         			`json:"state,omitempty"`
-	Country                  	string                         			`json:"country,omitempty"`
-	DefaultCurrency          	Currency                       			`json:"default_currency,omitempty"`
-	LegalName                	string                         			`json:"legal_name,omitempty"`
-	LegalNumber              	string                         			`json:"legal_number,omitempty"`
-	DocumentNumbering        	BillingEntityDocumentNumbering 			`json:"document_numbering,omitempty"`
-	DocumentNumberPrefix     	string                         			`json:"document_number_prefix,omitempty"`
-	NetPaymentTerm           	int                            			`json:"net_payment_term,omitempty"`
-	Timezone                 	string                         			`json:"timezone,omitempty"`
-	EmailSettings            	[]string                       			`json:"email_settings,omitempty"`
-	TaxIdentificationNumber  	string                         			`json:"tax_identification_number,omitempty"`
-	FinalizeZeroAmountInvoice 	bool                           			`json:"finalize_zero_amount_invoice,omitempty"`
-	EuTaxManagement          	bool                           			`json:"eu_tax_management,omitempty"`
-	BillingConfiguration 	  	BillingEntityBillingConfiguration 		`json:"billing_configuration,omitempty"`
-	LogoBase64                	string                         			`json:"logo,omitempty"`
+type BillingEntityCreateInput struct {
+	Name                      string                            `json:"name,omitempty"`
+	Code                      string                            `json:"code,omitempty"`
+	Email                     string                            `json:"email,omitempty"`
+	AddressLine1              string                            `json:"address_line1,omitempty"`
+	AddressLine2              string                            `json:"address_line2,omitempty"`
+	City                      string                            `json:"city,omitempty"`
+	Zipcode                   string                            `json:"zipcode,omitempty"`
+	State                     string                            `json:"state,omitempty"`
+	Country                   string                            `json:"country,omitempty"`
+	DefaultCurrency           Currency                          `json:"default_currency,omitempty"`
+	LegalName                 string                            `json:"legal_name,omitempty"`
+	LegalNumber               string                            `json:"legal_number,omitempty"`
+	DocumentNumbering         BillingEntityDocumentNumbering    `json:"document_numbering,omitempty"`
+	DocumentNumberPrefix      string                            `json:"document_number_prefix,omitempty"`
+	NetPaymentTerm            int                               `json:"net_payment_term,omitempty"`
+	Timezone                  string                            `json:"timezone,omitempty"`
+	EmailSettings             []string                          `json:"email_settings,omitempty"`
+	TaxIdentificationNumber   string                            `json:"tax_identification_number,omitempty"`
+	FinalizeZeroAmountInvoice bool                              `json:"finalize_zero_amount_invoice,omitempty"`
+	EuTaxManagement           bool                              `json:"eu_tax_management,omitempty"`
+	BillingConfiguration      BillingEntityBillingConfiguration `json:"billing_configuration,omitempty"`
+	LogoBase64                string                            `json:"logo,omitempty"`
 }
 
 type BillingEntityUpdateInput struct {
-	Name                     	string                         			`json:"name,omitempty"`
-	Email                    	string                         			`json:"email,omitempty"`
-	AddressLine1             	string                         			`json:"address_line1,omitempty"`
-	AddressLine2             	string                         			`json:"address_line2,omitempty"`
-	City                     	string                         			`json:"city,omitempty"`
-	Zipcode                  	string                         			`json:"zipcode,omitempty"`
-	State                    	string                         			`json:"state,omitempty"`
-	Country                  	string                         			`json:"country,omitempty"`
-	DefaultCurrency          	Currency                       			`json:"default_currency,omitempty"`
-	LegalName                	string                         			`json:"legal_name,omitempty"`
-	LegalNumber              	string                         			`json:"legal_number,omitempty"`
-	DocumentNumbering        	BillingEntityDocumentNumbering 			`json:"document_numbering,omitempty"`
-	DocumentNumberPrefix     	string                         			`json:"document_number_prefix,omitempty"`
-	NetPaymentTerm           	int                            			`json:"net_payment_term,omitempty"`
-	Timezone                 	string                         			`json:"timezone,omitempty"`
-	EmailSettings            	[]string                       			`json:"email_settings,omitempty"`
-	TaxIdentificationNumber  	string                         			`json:"tax_identification_number,omitempty"`
-	FinalizeZeroAmountInvoice 	bool                           			`json:"finalize_zero_amount_invoice,omitempty"`
-	EuTaxManagement          	bool                           			`json:"eu_tax_management,omitempty"`
-	BillingConfiguration 	  	BillingEntityBillingConfiguration 		`json:"billing_configuration,omitempty"`
-	LogoBase64                	string                         			`json:"logo,omitempty"`
-	TaxCodes                    []string                       			`json:"tax_codes,omitempty"`
+	Name                      string                            `json:"name,omitempty"`
+	Email                     string                            `json:"email,omitempty"`
+	AddressLine1              string                            `json:"address_line1,omitempty"`
+	AddressLine2              string                            `json:"address_line2,omitempty"`
+	City                      string                            `json:"city,omitempty"`
+	Zipcode                   string                            `json:"zipcode,omitempty"`
+	State                     string                            `json:"state,omitempty"`
+	Country                   string                            `json:"country,omitempty"`
+	DefaultCurrency           Currency                          `json:"default_currency,omitempty"`
+	LegalName                 string                            `json:"legal_name,omitempty"`
+	LegalNumber               string                            `json:"legal_number,omitempty"`
+	DocumentNumbering         BillingEntityDocumentNumbering    `json:"document_numbering,omitempty"`
+	DocumentNumberPrefix      string                            `json:"document_number_prefix,omitempty"`
+	NetPaymentTerm            int                               `json:"net_payment_term,omitempty"`
+	Timezone                  string                            `json:"timezone,omitempty"`
+	EmailSettings             []string                          `json:"email_settings,omitempty"`
+	TaxIdentificationNumber   string                            `json:"tax_identification_number,omitempty"`
+	FinalizeZeroAmountInvoice bool                              `json:"finalize_zero_amount_invoice,omitempty"`
+	EuTaxManagement           bool                              `json:"eu_tax_management,omitempty"`
+	BillingConfiguration      BillingEntityBillingConfiguration `json:"billing_configuration,omitempty"`
+	LogoBase64                string                            `json:"logo,omitempty"`
+	TaxCodes                  []string                          `json:"tax_codes,omitempty"`
 }
 
 func (c *Client) BillingEntity() *BillingEntityRequest {

--- a/credit_note.go
+++ b/credit_note.go
@@ -79,7 +79,7 @@ type CreditNoteAppliedTax struct {
 
 type CreditNote struct {
 	LagoID            uuid.UUID        `json:"lago_id,omitempty"`
-	SequentialID  	  int              `json:"sequential_id,omitempty"`
+	SequentialID      int              `json:"sequential_id,omitempty"`
 	BillingEntityCode string           `json:"billing_entity_code,omitempty"`
 	Number            string           `json:"number,omitempty"`
 	LagoInvoiceID     uuid.UUID        `json:"lago_invoice_id,omitempty"`

--- a/organization.go
+++ b/organization.go
@@ -84,7 +84,6 @@ type Organization struct {
 	EmailSettings             []string                      `json:"email_settings,omitempty"`
 	FinalizeZeroAmountInvoice bool                          `json:"finalize_zero_amount_invoice,omitempty"`
 
-
 	BillingConfiguration OrganizationBillingConfiguration `json:"billing_configuration,omitempty"`
 
 	Taxes []Tax `json:"taxes,omitempty"`

--- a/payment.go
+++ b/payment.go
@@ -20,11 +20,11 @@ type PaymentResult struct {
 }
 
 type PaymentListInput struct {
-	PerPage 			int `json:"per_page,omitempty,string"`
-	Page				int `json:"page,omitempty,string"`
+	PerPage int `json:"per_page,omitempty,string"`
+	Page    int `json:"page,omitempty,string"`
 
-	ExternalCustomerID	string `json:"external_customer_id,omitempty"`
-	InvoiceID 			string `json:"invoice_id,omitempty"`
+	ExternalCustomerID string `json:"external_customer_id,omitempty"`
+	InvoiceID          string `json:"invoice_id,omitempty"`
 }
 
 type NextAction struct {
@@ -56,10 +56,10 @@ type PaymentParams struct {
 }
 
 type PaymentInput struct {
-	InvoiceId	string		`json:"invoice_id,omitempty"`
-	AmountCents int   		`json:"amount_cents,omitempty"`
-	Reference	string		`json:"reference,omitempty"`
-	PaidAt		string		`json:"paid_at,omitempty"`
+	InvoiceId   string `json:"invoice_id,omitempty"`
+	AmountCents int    `json:"amount_cents,omitempty"`
+	Reference   string `json:"reference,omitempty"`
+	PaidAt      string `json:"paid_at,omitempty"`
 }
 
 func (c *Client) Payment() *ManualPaymentRequest {

--- a/wallet.go
+++ b/wallet.go
@@ -19,16 +19,16 @@ const (
 type RecurringTransactionRuleInput struct {
 	LagoID                           uuid.UUID                   `json:"lago_id,omitempty"`
 	Interval                         string                      `json:"interval,omitempty"`
-    Method                           string                      `json:"method,omitempty"`
+	Method                           string                      `json:"method,omitempty"`
 	StartedAt                        *time.Time                  `json:"started_at,omitempty"`
-    ExpirationAt                     *time.Time                  `json:"expiration_at,omitempty"`
+	ExpirationAt                     *time.Time                  `json:"expiration_at,omitempty"`
 	TargetOngoingBalance             string                      `json:"target_ongoing_balance,omitempty"`
 	ThresholdCredits                 string                      `json:"threshold_credits,omitempty"`
 	Trigger                          string                      `json:"trigger,omitempty"`
 	PaidCredits                      string                      `json:"paid_credits,omitempty"`
 	GrantedCredits                   string                      `json:"granted_credits,omitempty"`
-    InvoiceRequiresSuccessfulPayment bool                        `json:"invoice_requires_successful_payment,omitempty"`
-    TransactionMetadata              []WalletTransactionMetadata `json:"transaction_metadata,omitempty"`
+	InvoiceRequiresSuccessfulPayment bool                        `json:"invoice_requires_successful_payment,omitempty"`
+	TransactionMetadata              []WalletTransactionMetadata `json:"transaction_metadata,omitempty"`
 }
 
 type RecurringTransactionRuleResponse struct {
@@ -186,9 +186,9 @@ func (bmr *WalletRequest) Create(ctx context.Context, walletInput *WalletInput) 
 }
 
 func (bmr *WalletRequest) Update(ctx context.Context, walletInput *WalletInput, walletID string) (*Wallet, *Error) {
-    walletParams := &WalletParams{
-        WalletInput: walletInput,
-    }
+	walletParams := &WalletParams{
+		WalletInput: walletInput,
+	}
 
 	subPath := fmt.Sprintf("%s/%s", "wallets", walletID)
 	clientRequest := &ClientRequest{

--- a/wallet_transaction.go
+++ b/wallet_transaction.go
@@ -55,13 +55,13 @@ type WalletTransactionInput struct {
 	PaidCredits                      string                      `json:"paid_credits,omitempty"`
 	GrantedCredits                   string                      `json:"granted_credits,omitempty"`
 	VoidedCredits                    string                      `json:"voided_credits,omitempty"`
-    InvoiceRequiresSuccessfulPayment bool                        `json:"invoice_requires_successful_payment,omitempty"`
-    Metadata                         []WalletTransactionMetadata `json:"metadata,omitempty"`
+	InvoiceRequiresSuccessfulPayment bool                        `json:"invoice_requires_successful_payment,omitempty"`
+	Metadata                         []WalletTransactionMetadata `json:"metadata,omitempty"`
 }
 
 type WalletTransactionMetadata struct {
-    Key   string `json:"key"`
-    Value string `json:"value"`
+	Key   string `json:"key"`
+	Value string `json:"value"`
 }
 
 type WalletTransactionResult struct {
@@ -70,17 +70,17 @@ type WalletTransactionResult struct {
 }
 
 type WalletTransaction struct {
-	LagoID                           uuid.UUID                           `json:"lago_id,omitempty"`
-	LagoWalletID                     uuid.UUID                           `json:"lago_wallet_id,omitempty"`
-	Status                           WalletTransactionStatus             `json:"status,omitempty"`
-	TransactionType                  TransactionType                     `json:"transaction_type,omitempty"`
-	Amount                           string                              `json:"amount,omitempty"`
-	CreditAmount                     string                              `json:"credit_amount,omitempty"`
-    InvoiceRequiresSuccessfulPayment bool                                `json:"invoice_requires_successful_payment,omitempty"`
-	CreatedAt                        time.Time                           `json:"created_at,omitempty"`
-	SettledAt                        time.Time                           `json:"settled_at,omitempty"`
-	FailedAt                         time.Time                           `json:"failed_at,omitempty"`
-    Metadata                         []WalletTransactionMetadata         `json:"metadata,omitempty"`
+	LagoID                           uuid.UUID                   `json:"lago_id,omitempty"`
+	LagoWalletID                     uuid.UUID                   `json:"lago_wallet_id,omitempty"`
+	Status                           WalletTransactionStatus     `json:"status,omitempty"`
+	TransactionType                  TransactionType             `json:"transaction_type,omitempty"`
+	Amount                           string                      `json:"amount,omitempty"`
+	CreditAmount                     string                      `json:"credit_amount,omitempty"`
+	InvoiceRequiresSuccessfulPayment bool                        `json:"invoice_requires_successful_payment,omitempty"`
+	CreatedAt                        time.Time                   `json:"created_at,omitempty"`
+	SettledAt                        time.Time                   `json:"settled_at,omitempty"`
+	FailedAt                         time.Time                   `json:"failed_at,omitempty"`
+	Metadata                         []WalletTransactionMetadata `json:"metadata,omitempty"`
 }
 
 type WalletTransactionPaymentUrl struct {


### PR DESCRIPTION
This PR runs `gofmt` on all Go files in the project and adds a GitHub Actions workflow to ensure that `gofmt` is run on every push and pull request.

I wasn't sure whether to create a new workflow or add a new job within the existing workflow. I can update it if needed.

The new workflow was tested within https://github.com/getlago/lago-go-client/pull/257/commits/fde6b39208fbad7eb598f0892fbd61c9f40123f0:

<img width="473" alt="Screenshot 2025-06-05 at 19 00 29" src="https://github.com/user-attachments/assets/9460f3d2-8069-4d19-ad77-e77aaf3f623b" />
