### PR TITLE
misc(testing): Move `HandlerFunc` into a `testing` package

### DIFF
--- a/coupon_test.go
+++ b/coupon_test.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	qt "github.com/frankban/quicktest"
+
+	lt "github.com/getlago/lago-go-client/testing"
 )
 
 // Mock JSON response structure
@@ -110,7 +112,7 @@ func TestAppliedCouponGetList(t *testing.T) {
 	t.Run("When no parameter is provided", func(t *testing.T) {
 		c := qt.New(t)
 
-		server := HandlerFunc(c, mockResponse, func(c *qt.C, r *http.Request) {
+		server := lt.HandlerFunc(c, mockResponse, func(c *qt.C, r *http.Request) {
 			c.Assert(r.Method, qt.Equals, "GET")
 			c.Assert(r.URL.Path, qt.Equals, "/api/v1/applied_coupons")
 			c.Assert(r.URL.Query().Encode(), qt.Equals, "")
@@ -128,7 +130,7 @@ func TestAppliedCouponGetList(t *testing.T) {
 	t.Run("When parameters are provided", func(t *testing.T) {
 		c := qt.New(t)
 
-		server := HandlerFunc(c, mockResponse, func(c *qt.C, r *http.Request) {
+		server := lt.HandlerFunc(c, mockResponse, func(c *qt.C, r *http.Request) {
 			c.Assert(r.Method, qt.Equals, "GET")
 			c.Assert(r.URL.Path, qt.Equals, "/api/v1/applied_coupons")
 			query := r.URL.Query()

--- a/credit_note_test.go
+++ b/credit_note_test.go
@@ -10,6 +10,8 @@ import (
 
 	qt "github.com/frankban/quicktest"
 	"github.com/google/uuid"
+
+	lt "github.com/getlago/lago-go-client/testing"
 )
 
 // Mock JSON response structure
@@ -312,7 +314,7 @@ func TestCreditNoteGet(t *testing.T) {
 
 		creditNoteUUID, _ := uuid.Parse("1a901a90-1a90-1a90-1a90-1a901a901a90")
 
-		server := HandlerFunc(c, mockCreditNoteResponse, func(c *qt.C, r *http.Request) {
+		server := lt.HandlerFunc(c, mockCreditNoteResponse, func(c *qt.C, r *http.Request) {
 			c.Assert(r.Method, qt.Equals, "GET")
 			c.Assert(r.URL.Path, qt.Equals, "/api/v1/credit_notes/1a901a90-1a90-1a90-1a90-1a901a901a90")
 		})
@@ -343,7 +345,7 @@ func TestCreditNoteDownload(t *testing.T) {
 
 		creditNoteUUID, _ := uuid.Parse("1a901a90-1a90-1a90-1a90-1a901a901a90")
 
-		server := HandlerFunc(c, mockCreditNoteResponse, func(c *qt.C, r *http.Request) {
+		server := lt.HandlerFunc(c, mockCreditNoteResponse, func(c *qt.C, r *http.Request) {
 			c.Assert(r.Method, qt.Equals, "POST")
 			c.Assert(r.URL.Path, qt.Equals, "/api/v1/credit_notes/1a901a90-1a90-1a90-1a90-1a901a901a90/download")
 		})
@@ -361,7 +363,7 @@ func TestCreditNoteDownload(t *testing.T) {
 
 		creditNoteUUID, _ := uuid.Parse("1a901a90-1a90-1a90-1a90-1a901a901a90")
 
-		server := HandlerFunc(c, nil, func(c *qt.C, r *http.Request) {
+		server := lt.HandlerFunc(c, nil, func(c *qt.C, r *http.Request) {
 			c.Assert(r.Method, qt.Equals, "POST")
 			c.Assert(r.URL.Path, qt.Equals, "/api/v1/credit_notes/1a901a90-1a90-1a90-1a90-1a901a901a90/download")
 		})
@@ -388,7 +390,7 @@ func TestCreditNoteGetList(t *testing.T) {
 	t.Run("When no parameters are provided", func(t *testing.T) {
 		c := qt.New(t)
 
-		server := HandlerFunc(c, mockCreditNoteListResponse, func(c *qt.C, r *http.Request) {
+		server := lt.HandlerFunc(c, mockCreditNoteListResponse, func(c *qt.C, r *http.Request) {
 			c.Assert(r.Method, qt.Equals, "GET")
 			c.Assert(r.URL.Path, qt.Equals, "/api/v1/credit_notes")
 			c.Assert(r.URL.Query().Encode(), qt.Equals, "")
@@ -407,7 +409,7 @@ func TestCreditNoteGetList(t *testing.T) {
 	t.Run("When parameters are provided", func(t *testing.T) {
 		c := qt.New(t)
 
-		server := HandlerFunc(c, mockCreditNoteListResponse, func(c *qt.C, r *http.Request) {
+		server := lt.HandlerFunc(c, mockCreditNoteListResponse, func(c *qt.C, r *http.Request) {
 			c.Assert(r.Method, qt.Equals, "GET")
 			c.Assert(r.URL.Path, qt.Equals, "/api/v1/credit_notes")
 
@@ -471,7 +473,7 @@ func TestCreditNoteCreate(t *testing.T) {
 	t.Run("When create is called", func(t *testing.T) {
 		c := qt.New(t)
 
-		server := HandlerFunc(c, mockCreditNoteResponse, func(c *qt.C, r *http.Request) {
+		server := lt.HandlerFunc(c, mockCreditNoteResponse, func(c *qt.C, r *http.Request) {
 			c.Assert(r.Method, qt.Equals, "POST")
 			c.Assert(r.URL.Path, qt.Equals, "/api/v1/credit_notes")
 
@@ -543,7 +545,7 @@ func TestCreditNoteUpdate(t *testing.T) {
 
 		creditNoteUUID, _ := uuid.Parse("1a901a90-1a90-1a90-1a90-1a901a901a90")
 
-		server := HandlerFunc(c, mockCreditNoteResponse, func(c *qt.C, r *http.Request) {
+		server := lt.HandlerFunc(c, mockCreditNoteResponse, func(c *qt.C, r *http.Request) {
 			c.Assert(r.Method, qt.Equals, "PUT")
 			c.Assert(r.URL.Path, qt.Equals, "/api/v1/credit_notes/1a901a90-1a90-1a90-1a90-1a901a901a90")
 
@@ -589,7 +591,7 @@ func TestCreditNoteVoid(t *testing.T) {
 
 		creditNoteUUID, _ := uuid.Parse("1a901a90-1a90-1a90-1a90-1a901a901a90")
 
-		server := HandlerFunc(c, mockCreditNoteResponse, func(c *qt.C, r *http.Request) {
+		server := lt.HandlerFunc(c, mockCreditNoteResponse, func(c *qt.C, r *http.Request) {
 			c.Assert(r.Method, qt.Equals, "PUT")
 			c.Assert(r.URL.Path, qt.Equals, "/api/v1/credit_notes/1a901a90-1a90-1a90-1a90-1a901a901a90/void")
 		})
@@ -624,7 +626,7 @@ func TestCreditNoteEstimate(t *testing.T) {
 	t.Run("When estimate is called", func(t *testing.T) {
 		c := qt.New(t)
 
-		server := HandlerFunc(c, mockCreditNoteEstimateResponse, func(c *qt.C, r *http.Request) {
+		server := lt.HandlerFunc(c, mockCreditNoteEstimateResponse, func(c *qt.C, r *http.Request) {
 			c.Assert(r.Method, qt.Equals, "POST")
 			c.Assert(r.URL.Path, qt.Equals, "/api/v1/credit_notes/estimate")
 

--- a/invoice_test.go
+++ b/invoice_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	lt "github.com/getlago/lago-go-client/testing"
+
 	qt "github.com/frankban/quicktest"
 	"github.com/google/uuid"
 )
@@ -237,7 +239,7 @@ func TestInvoiceGetList(t *testing.T) {
 	t.Run("When no parameters are provided", func(t *testing.T) {
 		c := qt.New(t)
 
-		server := HandlerFunc(c, mockInvoiceListResponse, func(c *qt.C, r *http.Request) {
+		server := lt.HandlerFunc(c, mockInvoiceListResponse, func(c *qt.C, r *http.Request) {
 			c.Assert(r.Method, qt.Equals, "GET")
 			c.Assert(r.URL.Path, qt.Equals, "/api/v1/invoices")
 			c.Assert(r.URL.Query().Encode(), qt.Equals, "")
@@ -264,7 +266,7 @@ func TestInvoiceGetList(t *testing.T) {
 	t.Run("When parameters are provided", func(t *testing.T) {
 		c := qt.New(t)
 
-		server := HandlerFunc(c, mockInvoiceListResponse, func(c *qt.C, r *http.Request) {
+		server := lt.HandlerFunc(c, mockInvoiceListResponse, func(c *qt.C, r *http.Request) {
 			c.Assert(r.Method, qt.Equals, "GET")
 			c.Assert(r.URL.Path, qt.Equals, "/api/v1/invoices")
 
@@ -335,7 +337,7 @@ func TestPaymentUrl(t *testing.T) {
 	t.Run("With an invoiceID in the request", func(t *testing.T) {
 		c := qt.New(t)
 
-		server := HandlerFunc(c, mockInvoicePaymentUrlResponse, func(c *qt.C, r *http.Request) {
+		server := lt.HandlerFunc(c, mockInvoicePaymentUrlResponse, func(c *qt.C, r *http.Request) {
 			c.Assert(r.Method, qt.Equals, "POST")
 			c.Assert(r.URL.Path, qt.Equals, "/api/v1/invoices/1a901a90-1a90-1a90-1a90-1a901a901a90/payment_url")
 		})

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -1,4 +1,4 @@
-package lago
+package testing
 
 import (
 	"encoding/json"


### PR DESCRIPTION
This moves the `HandlerFunc` into a `testing` package to avoid returning it as part of our public API.
