### PR TITLE
feat (wallets): add support for billable metric limitations

### DIFF
--- a/wallet.go
+++ b/wallet.go
@@ -57,7 +57,8 @@ type WalletParams struct {
 }
 
 type AppliesTo struct {
-	FeeTypes []string `json:"fee_types,omitempty"`
+	FeeTypes            []string `json:"fee_types,omitempty"`
+	BillableMetricCodes []string `json:"billable_metric_codes,omitempty"`
 }
 
 type WalletInput struct {


### PR DESCRIPTION
This PR adds support for limiting wallet consumption on specific billable metric types.

New attribute called `billable_metric_codes` is added inside `applies_to` object in both request and response.