### PR TITLE
test: Simplify test setup

### DIFF
--- a/invoice_test.go
+++ b/invoice_test.go
@@ -1,11 +1,11 @@
-package lago
+package lago_test
 
 import (
 	"context"
-	"net/http"
 	"testing"
 	"time"
 
+	. "github.com/getlago/lago-go-client"
 	lt "github.com/getlago/lago-go-client/testing"
 
 	qt "github.com/frankban/quicktest"
@@ -239,23 +239,14 @@ func TestInvoiceGetList(t *testing.T) {
 	t.Run("When no parameters are provided", func(t *testing.T) {
 		c := qt.New(t)
 
-		server := lt.HandlerFunc(c, mockInvoiceListResponse, func(c *qt.C, r *http.Request) {
-			c.Assert(r.Method, qt.Equals, "GET")
-			c.Assert(r.URL.Path, qt.Equals, "/api/v1/invoices")
-			c.Assert(r.URL.Query().Encode(), qt.Equals, "")
-
-			query := r.URL.Query()
-			c.Assert(query.Get("per_page"), qt.Equals, "")
-			c.Assert(query.Get("page"), qt.Equals, "")
-			c.Assert(query.Get("payment_overdue"), qt.Equals, "")
-			c.Assert(query.Get("partially_paid"), qt.Equals, "")
-			c.Assert(query.Get("self_billed"), qt.Equals, "")
-			c.Assert(query.Get("payment_dispute_lost"), qt.Equals, "")
-		})
+		server := lt.NewMockServer(c).
+			MatchMethod("GET").
+			MatchPath("/api/v1/invoices").
+			MatchQuery("").
+			MockResponse(mockInvoiceListResponse)
 		defer server.Close()
 
-		client := New().SetBaseURL(server.URL).SetApiKey("test_api_key")
-		result, err := client.Invoice().GetList(context.Background(), &InvoiceListInput{})
+		result, err := server.Client().Invoice().GetList(context.Background(), &InvoiceListInput{})
 		// The method interface should return `error` and not `*Error` but that would break the API.
 		// See https://go.dev/doc/faq#nil_error.
 
@@ -266,39 +257,38 @@ func TestInvoiceGetList(t *testing.T) {
 	t.Run("When parameters are provided", func(t *testing.T) {
 		c := qt.New(t)
 
-		server := lt.HandlerFunc(c, mockInvoiceListResponse, func(c *qt.C, r *http.Request) {
-			c.Assert(r.Method, qt.Equals, "GET")
-			c.Assert(r.URL.Path, qt.Equals, "/api/v1/invoices")
-
-			query := r.URL.Query()
-			c.Assert(query.Get("per_page"), qt.Equals, "10")
-			c.Assert(query.Get("page"), qt.Equals, "1")
-			c.Assert(query.Get("customer_external_id"), qt.Equals, "CUSTOMER_1")
-			c.Assert(query.Get("invoice_type"), qt.Equals, "subscription")
-			c.Assert(query.Get("status"), qt.Equals, "finalized")
-			c.Assert(query.Get("payment_status"), qt.Equals, "succeeded")
-			c.Assert(query.Get("issuing_date_from"), qt.Equals, "2022-09-14T00:00:00Z")
-			c.Assert(query.Get("issuing_date_to"), qt.Equals, "2022-09-14T23:59:59Z")
-			c.Assert(query.Get("amount_from"), qt.Equals, "10")
-			c.Assert(query.Get("amount_to"), qt.Equals, "1000")
-			c.Assert(query.Get("search_term"), qt.Equals, "credit")
-			c.Assert(query["billing_entity_ids[]"], qt.DeepEquals, []string{"1a901a90-1a90-1a90-1a90-1a901a901a90", "1a901a90-1a90-1a90-1a90-1a901a901a91"})
-			c.Assert(query.Get("currency"), qt.Equals, "EUR")
-			c.Assert(query.Get("payment_overdue"), qt.Equals, "true")
-			c.Assert(query.Get("partially_paid"), qt.Equals, "true")
-			c.Assert(query.Get("self_billed"), qt.Equals, "false")
-			c.Assert(query.Get("payment_dispute_lost"), qt.Equals, "true")
-			c.Assert(query.Get("metadata[key1]"), qt.Equals, "10")
-			c.Assert(query.Get("metadata[key2]"), qt.Equals, "value2")
-		})
+		server := lt.NewMockServer(c).
+			MatchMethod("GET").
+			MatchPath("/api/v1/invoices").
+			MatchQuery(map[string]interface{}{
+				"per_page":             "10",
+				"page":                 "1",
+				"customer_external_id": "CUSTOMER_1",
+				"invoice_type":         "subscription",
+				"status":               "finalized",
+				"payment_status":       "succeeded",
+				"issuing_date_from":    "2022-09-14T00:00:00Z",
+				"issuing_date_to":      "2022-09-14T23:59:59Z",
+				"amount_from":          "10",
+				"amount_to":            "1000",
+				"search_term":          "credit",
+				"billing_entity_ids[]": []string{"1a901a90-1a90-1a90-1a90-1a901a901a90", "1a901a90-1a90-1a90-1a90-1a901a901a91"},
+				"currency":             "EUR",
+				"payment_overdue":      "true",
+				"partially_paid":       "true",
+				"self_billed":          "false",
+				"payment_dispute_lost": "true",
+				"metadata[key1]":       "10",
+				"metadata[key2]":       "value2",
+			}).
+			MockResponse(mockInvoiceListResponse)
 		defer server.Close()
 
-		client := New().SetBaseURL(server.URL).SetApiKey("test_api_key")
 		// selfBilled := false
 		entityUUID, _ := uuid.Parse("1a901a90-1a90-1a90-1a90-1a901a901a90")
 		entityUUID2, _ := uuid.Parse("1a901a90-1a90-1a90-1a90-1a901a901a91")
 
-		result, err := client.Invoice().GetList(context.Background(), &InvoiceListInput{
+		result, err := server.Client().Invoice().GetList(context.Background(), &InvoiceListInput{
 			PerPage:            Ptr(10),
 			Page:               Ptr(1),
 			IssuingDateFrom:    "2022-09-14T00:00:00Z",
@@ -337,13 +327,13 @@ func TestPaymentUrl(t *testing.T) {
 	t.Run("With an invoiceID in the request", func(t *testing.T) {
 		c := qt.New(t)
 
-		server := lt.HandlerFunc(c, mockInvoicePaymentUrlResponse, func(c *qt.C, r *http.Request) {
-			c.Assert(r.Method, qt.Equals, "POST")
-			c.Assert(r.URL.Path, qt.Equals, "/api/v1/invoices/1a901a90-1a90-1a90-1a90-1a901a901a90/payment_url")
-		})
+		server := lt.NewMockServer(c).
+			MatchMethod("POST").
+			MatchPath("/api/v1/invoices/1a901a90-1a90-1a90-1a90-1a901a901a90/payment_url").
+			MockResponse(mockInvoicePaymentUrlResponse)
+		defer server.Close()
 
-		client := New().SetBaseURL(server.URL).SetApiKey("test_api_key")
-		result, err := client.Invoice().PaymentUrl(context.Background(), "1a901a90-1a90-1a90-1a90-1a901a901a90")
+		result, err := server.Client().Invoice().PaymentUrl(context.Background(), "1a901a90-1a90-1a90-1a90-1a901a901a90")
 
 		c.Assert(err == nil, qt.IsTrue)
 		assertPaymentUrlResponse(c, result)

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -4,13 +4,16 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 
 	qt "github.com/frankban/quicktest"
+	"github.com/getlago/lago-go-client"
 )
 
-func HandlerFunc(c *qt.C, mockResponse interface{}, assertRequestFunc func(*qt.C, *http.Request)) *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+func handlerFuncWithResponse(c *qt.C, responseFunc func() interface{}, assertRequestFunc func(*qt.C, *http.Request)) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequestFunc(c, r)
+		mockResponse := responseFunc()
 		if mockResponse == nil {
 			return
 		}
@@ -26,5 +29,104 @@ func HandlerFunc(c *qt.C, mockResponse interface{}, assertRequestFunc func(*qt.C
 		}
 
 		c.Fatalf("Invalid mock response type: %T", mockResponse)
+	})
+}
+func ServerWithAssertions(c *qt.C, mockResponse interface{}, assertRequestFunc func(*qt.C, *http.Request)) *httptest.Server {
+	responseFunc := func() interface{} {
+		return mockResponse
+	}
+	return httptest.NewServer(handlerFuncWithResponse(c, responseFunc, assertRequestFunc))
+}
+
+type MockServer struct {
+	c              *qt.C
+	server         *httptest.Server
+	called         bool
+	expectedMethod string
+	expectedPath   string
+	expectedQuery  *string
+	mockResponse   interface{}
+}
+
+func NewMockServer(c *qt.C) *MockServer {
+	mockServer := &MockServer{c: c}
+	responseFunc := func() interface{} {
+		return mockServer.mockResponse
+	}
+	mockServer.server = httptest.NewServer(handlerFuncWithResponse(c, responseFunc, func(c *qt.C, r *http.Request) {
+		apiKey := r.Header.Get("Authorization")
+		mockServer.c.Assert(apiKey, qt.Equals, "Bearer test_api_key")
+		mockServer.called = true
+		if mockServer.expectedMethod != "" {
+			c.Assert(r.Method, qt.Equals, mockServer.expectedMethod)
+		}
+		if mockServer.expectedPath != "" {
+			c.Assert(r.URL.Path, qt.Equals, mockServer.expectedPath)
+		}
+		if mockServer.expectedQuery != nil {
+			parsedQuery, err := url.ParseQuery(*mockServer.expectedQuery)
+			mockServer.c.Assert(err, qt.IsNil)
+			c.Assert(r.URL.Query(), qt.DeepEquals, parsedQuery)
+		}
 	}))
+	return mockServer
+}
+
+func (m *MockServer) MatchMethod(method string) *MockServer {
+	m.expectedMethod = method
+	return m
+}
+
+func (m *MockServer) MatchPath(path string) *MockServer {
+	m.expectedPath = path
+	return m
+}
+
+func (m *MockServer) MatchQuery(queryParams interface{}) *MockServer {
+	switch mapQueryParams := queryParams.(type) {
+	case map[string]string:
+	case map[string][]string:
+	case map[string]interface{}:
+		urlValues := url.Values{}
+		for key, value := range mapQueryParams {
+			switch stringOrArrayValue := value.(type) {
+			case string:
+				urlValues.Add(key, stringOrArrayValue)
+			case []string:
+				for _, v := range stringOrArrayValue {
+					urlValues.Add(key, v)
+				}
+			}
+		}
+		str := urlValues.Encode()
+		m.expectedQuery = &str
+		return m
+	case string:
+		str := queryParams.(string)
+		m.expectedQuery = &str
+		return m
+	default:
+		m.c.Fatalf("Invalid query params type: %T", queryParams)
+	}
+
+	if queryString, ok := queryParams.(string); ok {
+		m.expectedQuery = &queryString
+		return m
+	}
+	m.c.Fatalf("Invalid query params type: %T", queryParams)
+	return m
+}
+
+func (m *MockServer) MockResponse(mockResponse interface{}) *MockServer {
+	m.mockResponse = mockResponse
+	return m
+}
+
+func (m *MockServer) Close() {
+	m.server.Close()
+	m.c.Assert(m.called, qt.IsTrue)
+}
+
+func (m MockServer) Client() *lago.Client {
+	return lago.New().SetBaseURL(m.server.URL).SetApiKey("test_api_key")
 }


### PR DESCRIPTION
This simplifies the way we manage server mocking by defining a `testing.MockServer` struct which includes a DSL to easily define assertions on request.

Instead of:

```go
server := lt.HandlerFunc(c, mockResponse, func(c *qt.C, r *http.Request) {
	c.Assert(r.Method, qt.Equals, "GET")
	c.Assert(r.URL.Path, qt.Equals, "/api/v1/applied_coupons")
	query := r.URL.Query()
	c.Assert(query.Get("external_customer_id"), qt.Equals, "CUSTOMER_1")
	c.Assert(query.Get("status"), qt.Equals, "active")
	c.Assert(query.Get("per_page"), qt.Equals, "10")
	c.Assert(query.Get("page"), qt.Equals, "1")
	c.Assert(query["coupon_code[]"], qt.DeepEquals, []string{"BLACK_FRIDAY", "CYBER_MONDAY"})
})

defer server.Close()

client := New().SetBaseURL(server.URL).SetApiKey("test_api_key")
result, err := client.AppliedCoupon().GetList(context.Background(), &AppliedCouponListInput{
```

We can now use:

```go
server := lt.NewMockServer(c).
	MatchMethod("GET").
	MatchPath("/api/v1/applied_coupons").
	MatchQuery(map[string]interface{}{
		"external_customer_id": "CUSTOMER_1",
		"status":               "active",
		"per_page":             "10",
		"page":                 "1",
		"coupon_code[]":        []string{"BLACK_FRIDAY", "CYBER_MONDAY"},
	}).
	MockResponse(mockResponse)
defer server.Close()

result, err := server.Client().AppliedCoupon().GetList(context.Background(), &lago.AppliedCouponListInput{
```

As the `testing.MockServer` relies on `lago.Client`, I had to update all the tests to be defined within the `lago_test` package to avoid circular references.

Also `testing.HandlerFunc` was renamed to `testing.ServerWithAssertions` to be more accurate.