### PR TITLE
feat(subscription): Allow refund as part of the subscription termination credit note

### DIFF
--- a/subscription.go
+++ b/subscription.go
@@ -30,6 +30,7 @@ type OnTerminationCreditNote string
 
 const (
 	OnTerminationCreditNoteCredit OnTerminationCreditNote = "credit"
+	OnTerminationCreditNoteRefund OnTerminationCreditNote = "refund"
 	OnTerminationCreditNoteSkip   OnTerminationCreditNote = "skip"
 )
 


### PR DESCRIPTION
This is related to https://github.com/getlago/lago-api/pull/4026.