### PR TITLE
feat: add support for billing interval on one-off invoices

### DIFF
--- a/invoice.go
+++ b/invoice.go
@@ -72,12 +72,14 @@ type InvoiceMetadataInput struct {
 }
 
 type InvoiceFeesInput struct {
-	AddOnCode          string   `json:"add_on_code,omitempty"`
-	InvoiceDisplayName string   `json:"invoice_display_name,omitempty"`
-	UnitAmountCents    int      `json:"unit_amount_cents,omitempty"`
-	Description        string   `json:"description,omitempty"`
-	Units              float32  `json:"units,omitempty"`
-	TaxCodes           []string `json:"tax_codes,omitempty"`
+	AddOnCode          string     `json:"add_on_code,omitempty"`
+	InvoiceDisplayName string     `json:"invoice_display_name,omitempty"`
+	UnitAmountCents    int        `json:"unit_amount_cents,omitempty"`
+	Description        string     `json:"description,omitempty"`
+	FromDatetime       *time.Time `json:"from_datetime,omitempty"`
+	ToDatetime         *time.Time `json:"to_datetime,omitempty"`
+	Units              float32    `json:"units,omitempty"`
+	TaxCodes           []string   `json:"tax_codes,omitempty"`
 }
 
 type InvoiceMetadataResponse struct {


### PR DESCRIPTION
We introduced one-off interval params that would be used for more precise analytics, but also for quotes feature that is coming soon.
