### PR TITLE
feat(semiannual): Add semiannual interval

### DIFF
--- a/plan.go
+++ b/plan.go
@@ -26,10 +26,11 @@ type PlanParams struct {
 type PlanInterval string
 
 const (
-	PlanWeekly    PlanInterval = "weekly"
-	PlanMonthly   PlanInterval = "monthly"
-	PlanQuarterly PlanInterval = "quarterly"
-	PlanYearly    PlanInterval = "yearly"
+	PlanWeekly     PlanInterval = "weekly"
+	PlanMonthly    PlanInterval = "monthly"
+	PlanQuarterly  PlanInterval = "quarterly"
+	PlanYearly     PlanInterval = "yearly"
+	PlanSemiannual PlanInterval = "semiannual"
 )
 
 type PlanChargeInput struct {


### PR DESCRIPTION
## Context

When creating a plan, a new interval option should be available: `semiannual`.
