### PR TITLE
Add Entitlements support

### DIFF
--- a/feature.go
+++ b/feature.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 )
 
 type FeatureRequest struct {
@@ -26,6 +27,7 @@ type Feature struct {
 	Code        string      `json:"code"`
 	Description string      `json:"description,omitempty"`
 	Privileges  []Privilege `json:"privileges,omitempty"`
+	CreatedAt   time.Time   `json:"created_at,omitempty"`
 }
 
 type FeatureResult struct {

--- a/feature.go
+++ b/feature.go
@@ -11,6 +11,15 @@ type FeatureRequest struct {
 	client *Client
 }
 
+type ValueType string
+
+const (
+	ValueTypeString  ValueType = "string"
+	ValueTypeInteger ValueType = "integer"
+	ValueTypeSelect  ValueType = "select"
+	ValueTypeBoolean ValueType = "boolean"
+)
+
 type PrivilegeConfig struct {
 	SelectOptions []string `json:"select_options,omitempty"`
 }
@@ -18,7 +27,7 @@ type PrivilegeConfig struct {
 type Privilege struct {
 	Code      string          `json:"code"`
 	Name      string          `json:"name,omitempty"`
-	ValueType string          `json:"value_type"` // TODO: add enum
+	ValueType ValueType       `json:"value_type"`
 	Config    PrivilegeConfig `json:"config"`
 }
 
@@ -26,8 +35,8 @@ type Feature struct {
 	Name        string      `json:"name,omitempty"`
 	Code        string      `json:"code"`
 	Description string      `json:"description,omitempty"`
-	Privileges  []Privilege `json:"privileges,omitempty"`
-	CreatedAt   time.Time   `json:"created_at,omitempty"`
+	Privileges  []Privilege `json:"privileges"`
+	CreatedAt   time.Time   `json:"created_at"`
 }
 
 type FeatureResult struct {
@@ -37,17 +46,18 @@ type FeatureResult struct {
 }
 
 type FeatureListInput struct {
-	PerPage int `json:"per_page,omitempty,string"`
-	Page    int `json:"page,omitempty,string"`
+	PerPage    *int   `json:"per_page,omitempty,string"`
+	Page       *int   `json:"page,omitempty,string"`
+	SearchTerm string `json:"search_term,omitempty"`
 }
 
 type FeatureParams struct {
-	FeatureInput *FeatureInput `json:"feature,omitempty"`
+	FeatureInput *FeatureInput `json:"feature"`
 }
 
 type FeatureInput struct {
 	Name        string           `json:"name,omitempty"`
-	Code        string           `json:"code,omitempty"`
+	Code        string           `json:"code"`
 	Description string           `json:"description,omitempty"`
 	Privileges  []PrivilegeInput `json:"privileges,omitempty"`
 }
@@ -57,9 +67,9 @@ type ConfigInput struct {
 }
 
 type PrivilegeInput struct {
-	Code      string      `json:"code,omitempty"`
+	Code      string      `json:"code"`
 	Name      string      `json:"name,omitempty"`
-	ValueType string      `json:"value_type,omitempty"`
+	ValueType ValueType   `json:"value_type,omitempty"`
 	Config    ConfigInput `json:"config,omitempty"`
 }
 

--- a/feature.go
+++ b/feature.go
@@ -10,11 +10,15 @@ type FeatureRequest struct {
 	client *Client
 }
 
+type PrivilegeConfig struct {
+	SelectOptions []string `json:"select_options,omitempty"`
+}
+
 type Privilege struct {
-	Code      string `json:"code"`
-	Name      string `json:"name,omitempty"`
-	ValueType string `json:"value_type"` // TODO: add enum
-	// TODO: Add config
+	Code      string          `json:"code"`
+	Name      string          `json:"name,omitempty"`
+	ValueType string          `json:"value_type"` // TODO: add enum
+	Config    PrivilegeConfig `json:"config"`
 }
 
 type Feature struct {
@@ -46,11 +50,46 @@ type FeatureInput struct {
 	Privileges  []PrivilegeInput `json:"privileges,omitempty"`
 }
 
+type ConfigInput struct {
+	SelectOptions []string `json:"select_options,omitempty"`
+}
+
 type PrivilegeInput struct {
-	Code      string `json:"code,omitempty"`
-	Name      string `json:"name,omitempty"`
-	ValueType string `json:"value_type,omitempty"`
-	// TODO: Add config
+	Code      string      `json:"code,omitempty"`
+	Name      string      `json:"name,omitempty"`
+	ValueType string      `json:"value_type,omitempty"`
+	Config    ConfigInput `json:"config,omitempty"`
+}
+
+type EntitlementsInput struct {
+	Entitlements []EntitlementInput `json:"entitlements"`
+}
+
+type EntitlementsInputMap map[string]map[string]any
+
+func (p EntitlementsInput) MarshalJSON() ([]byte, error) {
+	result := make(EntitlementsInputMap, len(p.Entitlements))
+	for _, ent := range p.Entitlements {
+		privilegeMap := make(map[string]any, len(ent.Privileges))
+
+		for _, privilege := range ent.Privileges {
+			privilegeMap[privilege.Code] = privilege.Value
+		}
+
+		result[ent.Code] = privilegeMap
+	}
+
+	return json.Marshal(map[string]EntitlementsInputMap{"entitlements": result})
+}
+
+type EntitlementPrivilegeInput struct {
+	Code  string `json:"code"`
+	Value any    `json:"value"`
+}
+
+type EntitlementInput struct {
+	Code       string                      `json:"code"`
+	Privileges []EntitlementPrivilegeInput `json:"privileges"`
 }
 
 func (c *Client) Feature() *FeatureRequest {

--- a/feature.go
+++ b/feature.go
@@ -1,0 +1,196 @@
+package lago
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+type FeatureRequest struct {
+	client *Client
+}
+
+type Privilege struct {
+	Code      string `json:"code"`
+	Name      string `json:"name,omitempty"`
+	ValueType string `json:"value_type"` // TODO: add enum
+	// TODO: Add config
+}
+
+type Feature struct {
+	Name        string      `json:"name,omitempty"`
+	Code        string      `json:"code"`
+	Description string      `json:"description,omitempty"`
+	Privileges  []Privilege `json:"privileges,omitempty"`
+}
+
+type FeatureResult struct {
+	Feature  *Feature  `json:"feature,omitempty"`
+	Features []Feature `json:"features,omitempty"`
+	Meta     Metadata  `json:"meta,omitempty"`
+}
+
+type FeatureListInput struct {
+	PerPage int `json:"per_page,omitempty,string"`
+	Page    int `json:"page,omitempty,string"`
+}
+
+type FeatureParams struct {
+	FeatureInput *FeatureInput `json:"feature,omitempty"`
+}
+
+type FeatureInput struct {
+	Name        string           `json:"name,omitempty"`
+	Code        string           `json:"code,omitempty"`
+	Description string           `json:"description,omitempty"`
+	Privileges  []PrivilegeInput `json:"privileges,omitempty"`
+}
+
+type PrivilegeInput struct {
+	Code      string `json:"code,omitempty"`
+	Name      string `json:"name,omitempty"`
+	ValueType string `json:"value_type,omitempty"`
+	// TODO: Add config
+}
+
+func (c *Client) Feature() *FeatureRequest {
+	return &FeatureRequest{
+		client: c,
+	}
+}
+
+func (bmr *FeatureRequest) Get(ctx context.Context, featureCode string) (*Feature, *Error) {
+	subPath := fmt.Sprintf("%s/%s", "features", featureCode)
+	clientRequest := &ClientRequest{
+		Path:   subPath,
+		Result: &FeatureResult{},
+	}
+
+	result, err := bmr.client.Get(ctx, clientRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	featureResult, ok := result.(*FeatureResult)
+	if !ok {
+		return nil, &ErrorTypeAssert
+	}
+
+	return featureResult.Feature, nil
+}
+
+func (bmr *FeatureRequest) GetList(ctx context.Context, featureListInput *FeatureListInput) (*FeatureResult, *Error) {
+	jsonQueryParams, err := json.Marshal(featureListInput)
+	if err != nil {
+		return nil, &Error{Err: err}
+	}
+
+	queryParams := make(map[string]string)
+	if err = json.Unmarshal(jsonQueryParams, &queryParams); err != nil {
+		return nil, &Error{Err: err}
+	}
+
+	clientRequest := &ClientRequest{
+		Path:        "features",
+		QueryParams: queryParams,
+		Result:      &FeatureResult{},
+	}
+
+	result, clientErr := bmr.client.Get(ctx, clientRequest)
+	if clientErr != nil {
+		return nil, clientErr
+	}
+
+	featureResult, ok := result.(*FeatureResult)
+	if !ok {
+		return nil, &ErrorTypeAssert
+	}
+
+	return featureResult, nil
+}
+
+func (bmr *FeatureRequest) Create(ctx context.Context, featureInput *FeatureInput) (*Feature, *Error) {
+
+	clientRequest := &ClientRequest{
+		Path:   "features",
+		Result: &FeatureResult{},
+		Body: &FeatureParams{
+			FeatureInput: featureInput,
+		},
+	}
+
+	result, err := bmr.client.Post(ctx, clientRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	featureResult, ok := result.(*FeatureResult)
+	if !ok {
+		return nil, &ErrorTypeAssert
+	}
+
+	return featureResult.Feature, nil
+}
+
+func (bmr *FeatureRequest) Update(ctx context.Context, featureInput *FeatureInput) (*Feature, *Error) {
+	subPath := fmt.Sprintf("%s/%s", "features", featureInput.Code)
+	clientRequest := &ClientRequest{
+		Path:   subPath,
+		Result: &FeatureResult{},
+		Body: &FeatureParams{
+			FeatureInput: featureInput,
+		},
+	}
+
+	result, err := bmr.client.Put(ctx, clientRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	featureResult, ok := result.(*FeatureResult)
+	if !ok {
+		return nil, &ErrorTypeAssert
+	}
+
+	return featureResult.Feature, nil
+}
+
+func (bmr *FeatureRequest) Delete(ctx context.Context, featureCode string) (*Feature, *Error) {
+	subPath := fmt.Sprintf("%s/%s", "features", featureCode)
+	clientRequest := &ClientRequest{
+		Path:   subPath,
+		Result: &FeatureResult{},
+	}
+
+	result, err := bmr.client.Delete(ctx, clientRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	featureResult, ok := result.(*FeatureResult)
+	if !ok {
+		return nil, &ErrorTypeAssert
+	}
+
+	return featureResult.Feature, nil
+}
+
+func (bmr *FeatureRequest) DeletePrivilege(ctx context.Context, featureCode string, privilegeCode string) (*Feature, *Error) {
+	subPath := fmt.Sprintf("%s/%s/%s/%s", "features", featureCode, "privileges", privilegeCode)
+	clientRequest := &ClientRequest{
+		Path:   subPath,
+		Result: &FeatureResult{},
+	}
+
+	result, err := bmr.client.Delete(ctx, clientRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	featureResult, ok := result.(*FeatureResult)
+	if !ok {
+		return nil, &ErrorTypeAssert
+	}
+
+	return featureResult.Feature, nil
+}

--- a/lago.go
+++ b/lago.go
@@ -144,6 +144,40 @@ func (c *Client) Get(ctx context.Context, cr *ClientRequest) (interface{}, *Erro
 	return resp.String(), nil
 }
 
+func (c *Client) Patch(ctx context.Context, cr *ClientRequest) (interface{}, *Error) {
+	httpClient := c.HttpClient
+	if cr.UseIngestService {
+		httpClient = c.IngestHttpClient
+	}
+
+	resp, err := httpClient.R().
+		SetContext(ctx).
+		SetError(&Error{}).
+		SetResult(cr.Result).
+		SetBody(cr.Body).
+		Patch(cr.Path)
+
+	if err != nil {
+		return nil, &Error{Err: err}
+	}
+
+	if c.Debug {
+		fmt.Println("REQUEST: ", resp.Request.RawRequest)
+		fmt.Println("RESPONSE: ", resp.String())
+	}
+
+	if resp.IsError() {
+		err, ok := resp.Error().(*Error)
+		if !ok {
+			return nil, &ErrorTypeAssert
+		}
+
+		return nil, err
+	}
+
+	return resp.Result(), nil
+}
+
 func (c *Client) Post(ctx context.Context, cr *ClientRequest) (interface{}, *Error) {
 	httpClient := c.HttpClient
 	if cr.UseIngestService {

--- a/plan.go
+++ b/plan.go
@@ -104,8 +104,9 @@ type Plan struct {
 	Charges            []Charge           `json:"charges,omitempty"`
 	MinimumCommitment  *MinimumCommitment `json:"minimum_commitment"`
 
-	Taxes           []Tax            `json:"taxes,omitempty"`
-	UsageThresholds []UsageThreshold `json:"usage_thresholds,omitempty"`
+	Taxes           []Tax             `json:"taxes,omitempty"`
+	UsageThresholds []UsageThreshold  `json:"usage_thresholds,omitempty"`
+	Entitlements    []PlanEntitlement `json:"entitlements,omitempty"`
 }
 
 func (c *Client) Plan() *PlanRequest {

--- a/plan_entitlements.go
+++ b/plan_entitlements.go
@@ -1,0 +1,189 @@
+package lago
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+type PlanEntitlementRequest struct {
+	client *Client
+}
+
+type PlanEntitlement struct {
+	Code        string                     `json:"code"`
+	Name        string                     `json:"name,omitempty"`
+	Description string                     `json:"description,omitempty"`
+	Privileges  []PlanEntitlementPrivilege `json:"privileges"`
+}
+
+type PlanEntitlementPrivilege struct {
+	Code      string `json:"code"`
+	Name      string `json:"name,omitempty"`
+	ValueType string `json:"value_type,omitempty"`
+	// TODO: Add config
+	Value any `json:"value"`
+}
+
+type PlanEntitlementsInput struct {
+	Entitlements []PlanEntitlementInput `json:"entitlements"`
+}
+
+type PlanEntitlementsInputMap map[string]map[string]any
+
+func (p PlanEntitlementsInput) MarshalJSON() ([]byte, error) {
+	result := make(PlanEntitlementsInputMap, len(p.Entitlements))
+	for _, ent := range p.Entitlements {
+		privilegeMap := make(map[string]any, len(ent.Privileges))
+
+		for _, privilege := range ent.Privileges {
+			privilegeMap[privilege.Code] = privilege.Value
+		}
+
+		result[ent.Code] = privilegeMap
+	}
+
+	return json.Marshal(map[string]PlanEntitlementsInputMap{"entitlements": result})
+}
+
+type PlanEntitlementPrivilegeInput struct {
+	Code  string `json:"code"`
+	Value any    `json:"value"`
+}
+
+type PlanEntitlementInput struct {
+	Code       string                          `json:"code"`
+	Privileges []PlanEntitlementPrivilegeInput `json:"privileges"`
+}
+
+type PlanEntitlementResult struct {
+	Entitlement  *PlanEntitlement  `json:"entitlement,omitempty"`
+	Entitlements []PlanEntitlement `json:"entitlements,omitempty"`
+}
+
+func (c *Client) PlanEntitlement() *PlanEntitlementRequest {
+	return &PlanEntitlementRequest{
+		client: c,
+	}
+}
+
+func (sr *PlanEntitlementRequest) GetList(ctx context.Context, planCode string) (*PlanEntitlementResult, *Error) {
+	subPath := fmt.Sprintf("%s/%s/%s", "plans", planCode, "entitlements")
+
+	clientRequest := &ClientRequest{
+		Path:   subPath,
+		Result: &PlanEntitlementResult{},
+	}
+
+	result, clientErr := sr.client.Get(ctx, clientRequest)
+	if clientErr != nil {
+		return nil, clientErr
+	}
+
+	planEntitlementResult, ok := result.(*PlanEntitlementResult)
+	if !ok {
+		return nil, &ErrorTypeAssert
+	}
+
+	return planEntitlementResult, nil
+}
+
+func (sr *PlanEntitlementRequest) Get(ctx context.Context, planCode string, featureCode string) (*PlanEntitlement, *Error) {
+	subPath := fmt.Sprintf("%s/%s/%s/%s", "plans", planCode, "entitlements", featureCode)
+
+	clientRequest := &ClientRequest{
+		Path:   subPath,
+		Result: &PlanEntitlementResult{},
+	}
+
+	result, clientErr := sr.client.Get(ctx, clientRequest)
+	if clientErr != nil {
+		return nil, clientErr
+	}
+
+	planEntitlementResult, ok := result.(*PlanEntitlementResult)
+	if !ok {
+		return nil, &ErrorTypeAssert
+	}
+
+	return planEntitlementResult.Entitlement, nil
+}
+
+func (sr *PlanEntitlementRequest) Delete(ctx context.Context, planCode string, featureCode string) (*PlanEntitlement, *Error) {
+	subPath := fmt.Sprintf("%s/%s/%s/%s", "plans", planCode, "entitlements", featureCode)
+
+	clientRequest := &ClientRequest{
+		Path:   subPath,
+		Result: &PlanEntitlementResult{},
+	}
+
+	result, clientErr := sr.client.Delete(ctx, clientRequest)
+	if clientErr != nil {
+		return nil, clientErr
+	}
+
+	planEntitlementResult, ok := result.(*PlanEntitlementResult)
+	if !ok {
+		return nil, &ErrorTypeAssert
+	}
+
+	return planEntitlementResult.Entitlement, nil
+}
+
+func (sr *PlanEntitlementRequest) DeletePrivilege(ctx context.Context, planCode string, featureCode string, privilegeCode string) (*PlanEntitlement, *Error) {
+	subPath := fmt.Sprintf("%s/%s/%s/%s/%s/%s", "plans", planCode, "entitlements", featureCode, "privileges", privilegeCode)
+
+	clientRequest := &ClientRequest{
+		Path:   subPath,
+		Result: &PlanEntitlementResult{},
+	}
+
+	result, clientErr := sr.client.Delete(ctx, clientRequest)
+	if clientErr != nil {
+		return nil, clientErr
+	}
+
+	planEntitlementResult, ok := result.(*PlanEntitlementResult)
+	if !ok {
+		return nil, &ErrorTypeAssert
+	}
+
+	return planEntitlementResult.Entitlement, nil
+}
+
+func (sr *PlanEntitlementRequest) Replace(ctx context.Context, planCode string, input []PlanEntitlementInput) (*PlanEntitlementResult, *Error) {
+	return sr.update(ctx, planCode, input, false)
+}
+
+func (sr *PlanEntitlementRequest) Update(ctx context.Context, planCode string, input []PlanEntitlementInput) (*PlanEntitlementResult, *Error) {
+	return sr.update(ctx, planCode, input, true)
+}
+
+func (sr *PlanEntitlementRequest) update(ctx context.Context, planCode string, input []PlanEntitlementInput, partial bool) (*PlanEntitlementResult, *Error) {
+	subPath := fmt.Sprintf("%s/%s/%s", "plans", planCode, "entitlements")
+
+	clientRequest := &ClientRequest{
+		Path:   subPath,
+		Result: &PlanEntitlementResult{},
+		Body:   PlanEntitlementsInput{Entitlements: input},
+	}
+
+	var result interface{}
+	var clientErr *Error
+
+	if partial {
+		result, clientErr = sr.client.Patch(ctx, clientRequest)
+	} else {
+		result, clientErr = sr.client.Post(ctx, clientRequest)
+	}
+	if clientErr != nil {
+		return nil, clientErr
+	}
+
+	planEntitlementResult, ok := result.(*PlanEntitlementResult)
+	if !ok {
+		return nil, &ErrorTypeAssert
+	}
+
+	return planEntitlementResult, nil
+}

--- a/plan_entitlements.go
+++ b/plan_entitlements.go
@@ -19,7 +19,7 @@ type PlanEntitlement struct {
 type PlanEntitlementPrivilege struct {
 	Code      string          `json:"code"`
 	Name      string          `json:"name"`
-	ValueType string          `json:"value_type"`
+	ValueType ValueType       `json:"value_type"`
 	Config    PrivilegeConfig `json:"config"`
 	Value     any             `json:"value"`
 }

--- a/subscription.go
+++ b/subscription.go
@@ -145,6 +145,8 @@ type Subscription struct {
 
 	Plan *Plan `json:"plan,omitempty"`
 
+	Entitlements []SubscriptionEntitlement `json:"entitlements,omitempty"`
+
 	CreatedAt    time.Time  `json:"created_at"`
 	StartedAt    *time.Time `json:"started_at"`
 	CanceledAt   *time.Time `json:"canceled_at"`

--- a/subscription_entitlements.go
+++ b/subscription_entitlements.go
@@ -19,8 +19,8 @@ type SubscriptionEntitlement struct {
 
 type SubscriptionEntitlementPrivilege struct {
 	Code          string          `json:"code"`
-	Name          string          `json:"name"`
-	ValueType     string          `json:"value_type"`
+	Name          string          `json:"name,omitempty"`
+	ValueType     ValueType       `json:"value_type"`
 	Config        PrivilegeConfig `json:"config"`
 	Value         any             `json:"value"`
 	PlanValue     any             `json:"plan_value"`

--- a/subscription_entitlements.go
+++ b/subscription_entitlements.go
@@ -1,0 +1,134 @@
+package lago
+
+import (
+	"context"
+	"fmt"
+)
+
+type SubscriptionEntitlementRequest struct {
+	client *Client
+}
+
+type SubscriptionEntitlement struct {
+	Code        string                             `json:"code"`
+	Name        string                             `json:"name"`
+	Description string                             `json:"description"`
+	Privileges  []SubscriptionEntitlementPrivilege `json:"privileges"`
+	Overrides   map[string]any                     `json:"overrides"`
+}
+
+type SubscriptionEntitlementPrivilege struct {
+	Code          string          `json:"code"`
+	Name          string          `json:"name"`
+	ValueType     string          `json:"value_type"`
+	Config        PrivilegeConfig `json:"config"`
+	Value         any             `json:"value"`
+	PlanValue     any             `json:"plan_value"`
+	OverrideValue any             `json:"override_value"`
+}
+
+type SubscriptionEntitlementResult struct {
+	Entitlement  *SubscriptionEntitlement  `json:"entitlement,omitempty"`
+	Entitlements []SubscriptionEntitlement `json:"entitlements,omitempty"`
+}
+
+func (c *Client) SubscriptionEntitlement() *SubscriptionEntitlementRequest {
+	return &SubscriptionEntitlementRequest{
+		client: c,
+	}
+}
+
+func (sr *SubscriptionEntitlementRequest) GetList(ctx context.Context, subscriptionExternalId string) (*SubscriptionEntitlementResult, *Error) {
+	subPath := fmt.Sprintf("%s/%s/%s", "subscriptions", subscriptionExternalId, "entitlements")
+
+	clientRequest := &ClientRequest{
+		Path:   subPath,
+		Result: &SubscriptionEntitlementResult{},
+	}
+
+	result, clientErr := sr.client.Get(ctx, clientRequest)
+	if clientErr != nil {
+		return nil, clientErr
+	}
+
+	subscriptionEntitlementResult, ok := result.(*SubscriptionEntitlementResult)
+	if !ok {
+		return nil, &ErrorTypeAssert
+	}
+
+	return subscriptionEntitlementResult, nil
+}
+
+func (sr *SubscriptionEntitlementRequest) Delete(ctx context.Context, subscriptionExternalId string, featureCode string) (*SubscriptionEntitlementResult, *Error) {
+	subPath := fmt.Sprintf("%s/%s/%s/%s", "subscriptions", subscriptionExternalId, "entitlements", featureCode)
+
+	clientRequest := &ClientRequest{
+		Path:   subPath,
+		Result: &SubscriptionEntitlementResult{},
+	}
+
+	result, clientErr := sr.client.Delete(ctx, clientRequest)
+	if clientErr != nil {
+		return nil, clientErr
+	}
+
+	subscriptionEntitlementResult, ok := result.(*SubscriptionEntitlementResult)
+	if !ok {
+		return nil, &ErrorTypeAssert
+	}
+
+	return subscriptionEntitlementResult, nil
+}
+
+func (sr *SubscriptionEntitlementRequest) DeletePrivilege(ctx context.Context, subscriptionExternalId string, featureCode string, privilegeCode string) (*SubscriptionEntitlementResult, *Error) {
+	subPath := fmt.Sprintf("%s/%s/%s/%s/%s/%s", "subscriptions", subscriptionExternalId, "entitlements", featureCode, "privileges", privilegeCode)
+
+	clientRequest := &ClientRequest{
+		Path:   subPath,
+		Result: &SubscriptionEntitlementResult{},
+	}
+
+	result, clientErr := sr.client.Delete(ctx, clientRequest)
+	if clientErr != nil {
+		return nil, clientErr
+	}
+
+	subscriptionEntitlementResult, ok := result.(*SubscriptionEntitlementResult)
+	if !ok {
+		return nil, &ErrorTypeAssert
+	}
+
+	return subscriptionEntitlementResult, nil
+}
+func (sr *SubscriptionEntitlementRequest) Update(ctx context.Context, subscriptionExternalId string, input []EntitlementInput) (*SubscriptionEntitlementResult, *Error) {
+	return sr.update(ctx, subscriptionExternalId, input, true)
+}
+
+func (sr *SubscriptionEntitlementRequest) update(ctx context.Context, subscriptionExternalId string, input []EntitlementInput, partial bool) (*SubscriptionEntitlementResult, *Error) {
+	subPath := fmt.Sprintf("%s/%s/%s", "subscriptions", subscriptionExternalId, "entitlements")
+
+	clientRequest := &ClientRequest{
+		Path:   subPath,
+		Result: &SubscriptionEntitlementResult{},
+		Body:   EntitlementsInput{Entitlements: input},
+	}
+
+	var result interface{}
+	var clientErr *Error
+
+	if partial {
+		result, clientErr = sr.client.Patch(ctx, clientRequest)
+	} else {
+		result, clientErr = sr.client.Post(ctx, clientRequest)
+	}
+	if clientErr != nil {
+		return nil, clientErr
+	}
+
+	subscriptionEntitlementResult, ok := result.(*SubscriptionEntitlementResult)
+	if !ok {
+		return nil, &ErrorTypeAssert
+	}
+
+	return subscriptionEntitlementResult, nil
+}


### PR DESCRIPTION
- [x] expose `entitlements` in Plan object
- [x] expose `entitlements` in Subscription object (only available in webhook payload, not API response)
- [x] Add `c.Feature()` to manage features and privileges
- [x] Add `c.PlanEntitlements()` to manage entitlements of a plan
- [x] Add `c.SubscriptionEntitlements()` to manage entitlements of a subscription (overrides)

Tested with local scripts, making actual calls. I'm not too convinced with the mocked test so haven't committed them.