### PR TITLE
fix(invoice-listing): Use the correct param name for customer externa…

### DIFF
--- a/invoice.go
+++ b/invoice.go
@@ -118,8 +118,7 @@ type InvoiceListInput struct {
 	IssuingDateFrom string `url:"issuing_date_from,omitempty"`
 	IssuingDateTo   string `url:"issuing_date_to,omitempty"`
 
-	// NOTE: Expose the fields as ExternalCustomerID to keep consistency with other endpoints
-	ExternalCustomerID string `url:"customer_external_id,omitempty"`
+	ExternalCustomerID string `url:"external_customer_id,omitempty"`
 
 	InvoiceType   InvoiceType          `url:"invoice_type,omitempty"`
 	Status        InvoiceStatus        `url:"status,omitempty"`

--- a/invoice_test.go
+++ b/invoice_test.go
@@ -263,7 +263,7 @@ func TestInvoiceGetList(t *testing.T) {
 			MatchQuery(map[string]interface{}{
 				"per_page":             "10",
 				"page":                 "1",
-				"customer_external_id": "CUSTOMER_1",
+				"external_customer_id": "CUSTOMER_1",
 				"invoice_type":         "subscription",
 				"status":               "finalized",
 				"payment_status":       "succeeded",


### PR DESCRIPTION
For Invoices, `ExternalCustomerID` url is mapped as `customer_external_id`