### PR TITLE
feat(customers): Add new routes scoped to customers

### DIFF
--- a/api_log_test.go
+++ b/api_log_test.go
@@ -125,7 +125,7 @@ func assertApiLog(c *qt.C, apiLog ApiLog) {
 	c.Assert(apiLog.CreatedAt.Format(time.RFC3339), qt.Equals, "2025-06-20T14:34:25Z")
 }
 
-func TestApiLogGetList(t *testing.T) {
+func TestApiLogRequest_GetList(t *testing.T) {
 	t.Run("When query for all api logs", func(t *testing.T) {
 		c := qt.New(t)
 
@@ -141,7 +141,7 @@ func TestApiLogGetList(t *testing.T) {
 	})
 }
 
-func TestApiLogGet(t *testing.T) {
+func TestApiLogRequest_Get(t *testing.T) {
 	t.Run("When query for a specific api log", func(t *testing.T) {
 		c := qt.New(t)
 

--- a/coupon_test.go
+++ b/coupon_test.go
@@ -99,7 +99,7 @@ func assertAppliedCoupontGetListResponse(c *qt.C, result *AppliedCouponResult) {
 	c.Assert(result.Meta.TotalCount, qt.Equals, 1)
 }
 
-func TestAppliedCouponGetList(t *testing.T) {
+func TestAppliedCouponRequest_GetList(t *testing.T) {
 	t.Run("When the server is not reachable", func(t *testing.T) {
 		c := qt.New(t)
 

--- a/credit_note_test.go
+++ b/credit_note_test.go
@@ -299,7 +299,7 @@ func assertCreditNoteEstimateResponse(c *qt.C, result *EstimatedCreditNote) {
 	c.Assert(appliedTax.BaseAmountCents, qt.Equals, 100)
 }
 
-func TestCreditNoteGet(t *testing.T) {
+func TestCreditNoteRequest_Get(t *testing.T) {
 	t.Run("When the server is not reachable", func(t *testing.T) {
 		c := qt.New(t)
 
@@ -328,7 +328,7 @@ func TestCreditNoteGet(t *testing.T) {
 	})
 }
 
-func TestCreditNoteDownload(t *testing.T) {
+func TestCreditNoteRequest_Download(t *testing.T) {
 	t.Run("When the server is not reachable", func(t *testing.T) {
 		c := qt.New(t)
 
@@ -373,7 +373,7 @@ func TestCreditNoteDownload(t *testing.T) {
 	})
 }
 
-func TestCreditNoteGetList(t *testing.T) {
+func TestCreditNoteRequest_GetList(t *testing.T) {
 	t.Run("When the server is not reachable", func(t *testing.T) {
 		c := qt.New(t)
 
@@ -453,7 +453,7 @@ func TestCreditNoteGetList(t *testing.T) {
 	})
 }
 
-func TestCreditNoteCreate(t *testing.T) {
+func TestCreditNoteRequest_Create(t *testing.T) {
 	t.Run("When the server is not reachable", func(t *testing.T) {
 		c := qt.New(t)
 
@@ -519,7 +519,7 @@ func TestCreditNoteCreate(t *testing.T) {
 	})
 }
 
-func TestCreditNoteUpdate(t *testing.T) {
+func TestCreditNoteRequest_Update(t *testing.T) {
 	t.Run("When the server is not reachable", func(t *testing.T) {
 		c := qt.New(t)
 
@@ -567,7 +567,7 @@ func TestCreditNoteUpdate(t *testing.T) {
 	})
 }
 
-func TestCreditNoteVoid(t *testing.T) {
+func TestCreditNoteRequest_Void(t *testing.T) {
 	t.Run("When the server is not reachable", func(t *testing.T) {
 		c := qt.New(t)
 
@@ -596,7 +596,7 @@ func TestCreditNoteVoid(t *testing.T) {
 	})
 }
 
-func TestCreditNoteEstimate(t *testing.T) {
+func TestCreditNoteRequest_Estimate(t *testing.T) {
 	t.Run("When the server is not reachable", func(t *testing.T) {
 		c := qt.New(t)
 

--- a/customer_test.go
+++ b/customer_test.go
@@ -193,7 +193,7 @@ var mockCustomerSubscriptionListResponse = map[string]any{
 	},
 }
 
-func TestCustomerGetInvoiceList(t *testing.T) {
+func TestCustomerRequest_GetInvoiceList(t *testing.T) {
 	t.Run("When the server is not reachable", func(t *testing.T) {
 		c := qt.New(t)
 
@@ -260,7 +260,7 @@ func TestCustomerGetInvoiceList(t *testing.T) {
 	})
 }
 
-func TestCustomerGetCreditNoteList(t *testing.T) {
+func TestCustomerRequest_GetCreditNoteList(t *testing.T) {
 	t.Run("When the server is not reachable", func(t *testing.T) {
 		c := qt.New(t)
 
@@ -332,7 +332,7 @@ func TestCustomerGetCreditNoteList(t *testing.T) {
 	})
 }
 
-func TestCustomerGetPaymentList(t *testing.T) {
+func TestCustomerRequest_GetPaymentList(t *testing.T) {
 	t.Run("When the server is not reachable", func(t *testing.T) {
 		c := qt.New(t)
 
@@ -381,7 +381,7 @@ func TestCustomerGetPaymentList(t *testing.T) {
 	})
 }
 
-func TestCustomerGetPaymentRequestList(t *testing.T) {
+func TestCustomerRequest_GetPaymentRequestList(t *testing.T) {
 	t.Run("When the server is not reachable", func(t *testing.T) {
 		c := qt.New(t)
 
@@ -430,7 +430,7 @@ func TestCustomerGetPaymentRequestList(t *testing.T) {
 	})
 }
 
-func TestCustomerGetAppliedCouponList(t *testing.T) {
+func TestCustomerRequest_GetAppliedCouponList(t *testing.T) {
 	t.Run("When the server is not reachable", func(t *testing.T) {
 		c := qt.New(t)
 
@@ -480,7 +480,7 @@ func TestCustomerGetAppliedCouponList(t *testing.T) {
 	})
 }
 
-func TestCustomerGetSubscriptionList(t *testing.T) {
+func TestCustomerRequest_GetSubscriptionList(t *testing.T) {
 	t.Run("When the server is not reachable", func(t *testing.T) {
 		c := qt.New(t)
 

--- a/customer_test.go
+++ b/customer_test.go
@@ -1,0 +1,531 @@
+package lago_test
+
+import (
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	. "github.com/getlago/lago-go-client"
+	lt "github.com/getlago/lago-go-client/testing"
+)
+
+// Mock response for customer invoice list
+var mockCustomerInvoiceListResponse = map[string]any{
+	"invoices": []map[string]interface{}{
+		mockInvoice,
+	},
+	"meta": map[string]interface{}{
+		"current_page": 1,
+		"next_page":    0,
+		"prev_page":    0,
+		"total_pages":  1,
+		"total_count":  1,
+	},
+}
+
+// Mock response for customer credit note list
+var mockCustomerCreditNoteListResponse = map[string]any{
+	"credit_notes": []map[string]interface{}{
+		{
+			"lago_id":                                 "1a901a90-1a90-1a90-1a90-1a901a901a90",
+			"sequential_id":                           2,
+			"number":                                  "LAG-1234-CN-001-002",
+			"lago_invoice_id":                         "1a901a90-1a90-1a90-1a90-1a901a901a90",
+			"invoice_number":                          "LAG-1234-001-002",
+			"issuing_date":                            "2022-04-30",
+			"credit_status":                           "available",
+			"refund_status":                           "pending",
+			"reason":                                  "duplicated_charge",
+			"description":                             "Duplicated charge",
+			"currency":                                "EUR",
+			"total_amount_cents":                      120,
+			"credit_amount_cents":                     100,
+			"balance_amount_cents":                    100,
+			"refund_amount_cents":                     0,
+			"coupons_adjustment_amount_cents":         0,
+			"taxes_amount_cents":                      20,
+			"sub_total_excluding_taxes_amount_cents":  100,
+			"max_creditable_amount_cents":             100,
+			"max_refundable_amount_cents":             100,
+			"precise_coupons_adjustment_amount_cents": "0.0",
+			"created_at":                              "2022-04-29T08:59:51Z",
+			"updated_at":                              "2022-04-29T08:59:51Z",
+			"file_url":                                "https://getlago.com/credit_note/file",
+			"voided_at":                               nil,
+			"self_billed":                             false,
+		},
+	},
+	"meta": map[string]interface{}{
+		"current_page": 1,
+		"next_page":    0,
+		"prev_page":    0,
+		"total_pages":  1,
+		"total_count":  1,
+	},
+}
+
+// Mock response for customer payment list
+var mockCustomerPaymentListResponse = map[string]any{
+	"payments": []map[string]interface{}{
+		{
+			"lago_id":              "1a901a90-1a90-1a90-1a90-1a901a901a90",
+			"amount_cents":         1200,
+			"amount_currency":      "EUR",
+			"payment_status":       "succeeded",
+			"type":                 "manual",
+			"reference":            "REF-123456",
+			"external_payment_id":  "ext_payment_123",
+			"created_at":           "2022-04-29T08:59:51Z",
+			"invoice_ids":          []string{"1a901a90-1a90-1a90-1a90-1a901a901a90"},
+			"external_customer_id": "CUSTOMER_1",
+		},
+	},
+	"meta": map[string]interface{}{
+		"current_page": 1,
+		"next_page":    0,
+		"prev_page":    0,
+		"total_pages":  1,
+		"total_count":  1,
+	},
+}
+
+// Mock response for customer payment request list
+var mockCustomerPaymentRequestListResponse = map[string]any{
+	"payment_requests": []map[string]interface{}{
+		{
+			"lago_id":         "1a901a90-1a90-1a90-1a90-1a901a901a90",
+			"email":           "customer@example.com",
+			"amount_cents":    1200,
+			"amount_currency": "EUR",
+			"payment_status":  "pending",
+			"created_at":      "2022-04-29T08:59:51Z",
+			"customer": map[string]interface{}{
+				"lago_id":     "1a901a90-1a90-1a90-1a90-1a901a901a90",
+				"external_id": "CUSTOMER_1",
+				"name":        "John Doe",
+				"email":       "customer@example.com",
+			},
+			"invoices": []map[string]interface{}{
+				{
+					"lago_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
+					"number":  "LAG-1234-001-002",
+				},
+			},
+		},
+	},
+	"meta": map[string]interface{}{
+		"current_page": 1,
+		"next_page":    0,
+		"prev_page":    0,
+		"total_pages":  1,
+		"total_count":  1,
+	},
+}
+
+// Mock response for customer applied coupon list
+var mockCustomerAppliedCouponListResponse = map[string]any{
+	"applied_coupons": []map[string]interface{}{
+		{
+			"lago_id":                      "1a901a90-1a90-1a90-1a90-1a901a901a90",
+			"lago_coupon_id":               "1a901a90-1a90-1a90-1a90-1a901a901a90",
+			"coupon_code":                  "APPLIED_COUPON",
+			"coupon_name":                  "Startup Deal",
+			"lago_customer_id":             "1a901a90-1a90-1a90-1a90-1a901a901a90",
+			"external_customer_id":         "CUSTOMER_1",
+			"status":                       "active",
+			"amount_cents":                 2000,
+			"amount_cents_remaining":       50,
+			"amount_currency":              "EUR",
+			"percentage_rate":              nil,
+			"frequency":                    "recurring",
+			"frequency_duration":           3,
+			"frequency_duration_remaining": 1,
+			"expiration_at":                "2022-04-29T08:59:51Z",
+			"created_at":                   "2022-04-29T08:59:51Z",
+			"terminated_at":                "2022-04-29T08:59:51Z",
+		},
+	},
+	"meta": map[string]interface{}{
+		"current_page": 1,
+		"next_page":    0,
+		"prev_page":    0,
+		"total_pages":  1,
+		"total_count":  1,
+	},
+}
+
+// Mock response for customer subscription list
+var mockCustomerSubscriptionListResponse = map[string]any{
+	"subscriptions": []map[string]interface{}{
+		{
+			"lago_id":                           "1a901a90-1a90-1a90-1a90-1a901a901a90",
+			"external_id":                       "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+			"lago_customer_id":                  "1a901a90-1a90-1a90-1a90-1a901a901a90",
+			"external_customer_id":              "CUSTOMER_1",
+			"billing_time":                      "anniversary",
+			"name":                              "Repository A",
+			"plan_code":                         "premium",
+			"status":                            "active",
+			"created_at":                        "2022-08-08T00:00:00Z",
+			"started_at":                        "2022-08-08T00:00:00Z",
+			"subscription_at":                   "2022-08-08T00:00:00Z",
+			"current_billing_period_started_at": "2022-08-08T00:00:00Z",
+			"current_billing_period_ending_at":  "2022-09-08T00:00:00Z",
+			"on_termination_credit_note":        "skip",
+			"on_termination_invoice":            "skip",
+			"plan": map[string]interface{}{
+				"lago_id":         "1a901a90-1a90-1a90-1a90-1a901a901a90",
+				"name":            "Premium Plan",
+				"code":            "premium",
+				"interval":        "monthly",
+				"amount_cents":    10000,
+				"amount_currency": "USD",
+			},
+		},
+	},
+	"meta": map[string]interface{}{
+		"current_page": 1,
+		"next_page":    0,
+		"prev_page":    0,
+		"total_pages":  1,
+		"total_count":  1,
+	},
+}
+
+func TestCustomerGetInvoiceList(t *testing.T) {
+	t.Run("When the server is not reachable", func(t *testing.T) {
+		c := qt.New(t)
+
+		client := New().SetBaseURL("http://localhost:88888").SetApiKey("test_api_key")
+		result, err := client.Customer().GetInvoiceList(context.Background(), "CUSTOMER_1", &CustomerInvoiceListInput{})
+		c.Assert(result, qt.IsNil)
+		c.Assert(err.Error(), qt.Equals, `{"status":0,"error":"","code":"","err":"Get \"http://localhost:88888/api/v1/customers/CUSTOMER_1/invoices\": dial tcp: address 88888: invalid port"}`)
+	})
+
+	t.Run("When no parameters are provided", func(t *testing.T) {
+		c := qt.New(t)
+
+		server := lt.NewMockServer(c).
+			MatchMethod("GET").
+			MatchPath("/api/v1/customers/CUSTOMER_1/invoices").
+			MatchQuery("").
+			MockResponse(mockCustomerInvoiceListResponse)
+		defer server.Close()
+
+		result, err := server.Client().Customer().GetInvoiceList(context.Background(), "CUSTOMER_1", &CustomerInvoiceListInput{})
+		c.Assert(err == nil, qt.IsTrue)
+		c.Assert(result.Invoices, qt.HasLen, 1)
+		c.Assert(result.Meta.CurrentPage, qt.Equals, 1)
+		c.Assert(result.Meta.TotalCount, qt.Equals, 1)
+	})
+
+	t.Run("When parameters are provided", func(t *testing.T) {
+		c := qt.New(t)
+
+		server := lt.NewMockServer(c).
+			MatchMethod("GET").
+			MatchPath("/api/v1/customers/CUSTOMER_1/invoices").
+			MatchQuery("per_page=10&page=1&issuing_date_from=2022-01-01&issuing_date_to=2022-12-31&invoice_type=subscription&status=finalized&payment_status=succeeded&payment_overdue=true&partially_paid=false&self_billed=true&payment_dispute_lost=false&amount_from=100&amount_to=1000&search_term=test&currency=EUR").
+			MockResponse(mockCustomerInvoiceListResponse)
+		defer server.Close()
+
+		perPage := 10
+		page := 1
+		paymentOverdue := true
+		partiallyPaid := false
+		selfBilled := true
+		paymentDisputeLost := false
+		amountFrom := 100
+		amountTo := 1000
+		result, err := server.Client().Customer().GetInvoiceList(context.Background(), "CUSTOMER_1", &CustomerInvoiceListInput{
+			PerPage:            &perPage,
+			Page:               &page,
+			IssuingDateFrom:    "2022-01-01",
+			IssuingDateTo:      "2022-12-31",
+			InvoiceType:        SubscriptionInvoiceType,
+			Status:             InvoiceStatusFinalized,
+			PaymentStatus:      InvoicePaymentStatusSucceeded,
+			PaymentOverdue:     &paymentOverdue,
+			PartiallyPaid:      &partiallyPaid,
+			SelfBilled:         &selfBilled,
+			PaymentDisputeLost: &paymentDisputeLost,
+			AmountFrom:         &amountFrom,
+			AmountTo:           &amountTo,
+			SearchTerm:         "test",
+			Currency:           EUR,
+		})
+		c.Assert(err == nil, qt.IsTrue)
+		c.Assert(result.Invoices, qt.HasLen, 1)
+	})
+}
+
+func TestCustomerGetCreditNoteList(t *testing.T) {
+	t.Run("When the server is not reachable", func(t *testing.T) {
+		c := qt.New(t)
+
+		client := New().SetBaseURL("http://localhost:88888").SetApiKey("test_api_key")
+		result, err := client.Customer().GetCreditNoteList(context.Background(), "CUSTOMER_1", &CustomerCreditNoteListInput{})
+		c.Assert(result, qt.IsNil)
+		c.Assert(err.Error(), qt.Equals, `{"status":0,"error":"","code":"","err":"Get \"http://localhost:88888/api/v1/customers/CUSTOMER_1/credit_notes\": dial tcp: address 88888: invalid port"}`)
+	})
+
+	t.Run("When no parameters are provided", func(t *testing.T) {
+		c := qt.New(t)
+
+		server := lt.NewMockServer(c).
+			MatchMethod("GET").
+			MatchPath("/api/v1/customers/CUSTOMER_1/credit_notes").
+			MatchQuery("").
+			MockResponse(mockCustomerCreditNoteListResponse)
+		defer server.Close()
+
+		result, err := server.Client().Customer().GetCreditNoteList(context.Background(), "CUSTOMER_1", &CustomerCreditNoteListInput{})
+		c.Assert(err == nil, qt.IsTrue)
+		c.Assert(result.CreditNotes, qt.HasLen, 1)
+		c.Assert(result.Meta.CurrentPage, qt.Equals, 1)
+		c.Assert(result.Meta.TotalCount, qt.Equals, 1)
+	})
+
+	t.Run("When parameters are provided", func(t *testing.T) {
+		c := qt.New(t)
+
+		server := lt.NewMockServer(c).
+			MatchMethod("GET").
+			MatchPath("/api/v1/customers/CUSTOMER_1/credit_notes").
+			MatchQuery("per_page=10" +
+				"&page=1" +
+				"&issuing_date_from=2022-01-01" +
+				"&issuing_date_to=2022-12-31" +
+				"&amount_from=100" +
+				"&amount_to=1000" +
+				"&search_term=test" +
+				"&credit_status=available" +
+				"&currency=EUR" +
+				"&invoice_number=INV-001" +
+				"&reason=duplicated_charge" +
+				"&refund_status=pending" +
+				"&self_billed=true").
+			MockResponse(mockCustomerCreditNoteListResponse)
+		defer server.Close()
+
+		perPage := 10
+		page := 1
+		selfBilled := true
+		result, err := server.Client().Customer().GetCreditNoteList(context.Background(), "CUSTOMER_1", &CustomerCreditNoteListInput{
+			PerPage:         &perPage,
+			Page:            &page,
+			IssuingDateFrom: "2022-01-01",
+			IssuingDateTo:   "2022-12-31",
+			AmountFrom:      100,
+			AmountTo:        1000,
+			SearchTerm:      "test",
+			CreditStatus:    CreditNoteCreditStatusAvailable,
+			Currency:        EUR,
+			InvoiceNumber:   "INV-001",
+			Reason:          CreditNoteReasonDuplicatedCharge,
+			RefundStatus:    CreditNoteRefundStatusPending,
+			SelfBilled:      &selfBilled,
+		})
+		c.Assert(err == nil, qt.IsTrue)
+		c.Assert(result.CreditNotes, qt.HasLen, 1)
+	})
+}
+
+func TestCustomerGetPaymentList(t *testing.T) {
+	t.Run("When the server is not reachable", func(t *testing.T) {
+		c := qt.New(t)
+
+		client := New().SetBaseURL("http://localhost:88888").SetApiKey("test_api_key")
+		result, err := client.Customer().GetPaymentList(context.Background(), "CUSTOMER_1", &CustomerPaymentListInput{})
+		c.Assert(result, qt.IsNil)
+		c.Assert(err.Error(), qt.Equals, `{"status":0,"error":"","code":"","err":"Get \"http://localhost:88888/api/v1/customers/CUSTOMER_1/payments\": dial tcp: address 88888: invalid port"}`)
+	})
+
+	t.Run("When no parameters are provided", func(t *testing.T) {
+		c := qt.New(t)
+
+		server := lt.NewMockServer(c).
+			MatchMethod("GET").
+			MatchPath("/api/v1/customers/CUSTOMER_1/payments").
+			MatchQuery("").
+			MockResponse(mockCustomerPaymentListResponse)
+		defer server.Close()
+
+		result, err := server.Client().Customer().GetPaymentList(context.Background(), "CUSTOMER_1", &CustomerPaymentListInput{})
+		c.Assert(err == nil, qt.IsTrue)
+		c.Assert(result.Payments, qt.HasLen, 1)
+		c.Assert(result.Meta.CurrentPage, qt.Equals, 1)
+		c.Assert(result.Meta.TotalCount, qt.Equals, 1)
+	})
+
+	t.Run("When parameters are provided", func(t *testing.T) {
+		c := qt.New(t)
+
+		server := lt.NewMockServer(c).
+			MatchMethod("GET").
+			MatchPath("/api/v1/customers/CUSTOMER_1/payments").
+			MatchQuery("per_page=10&page=1&invoice_id=invoice_123").
+			MockResponse(mockCustomerPaymentListResponse)
+		defer server.Close()
+
+		perPage := 10
+		page := 1
+		result, err := server.Client().Customer().GetPaymentList(context.Background(), "CUSTOMER_1", &CustomerPaymentListInput{
+			PerPage:   &perPage,
+			Page:      &page,
+			InvoiceID: "invoice_123",
+		})
+		c.Assert(err == nil, qt.IsTrue)
+		c.Assert(result.Payments, qt.HasLen, 1)
+	})
+}
+
+func TestCustomerGetPaymentRequestList(t *testing.T) {
+	t.Run("When the server is not reachable", func(t *testing.T) {
+		c := qt.New(t)
+
+		client := New().SetBaseURL("http://localhost:88888").SetApiKey("test_api_key")
+		result, err := client.Customer().GetPaymentRequestList(context.Background(), "CUSTOMER_1", &CustomerPaymentRequestListInput{})
+		c.Assert(result, qt.IsNil)
+		c.Assert(err.Error(), qt.Equals, `{"status":0,"error":"","code":"","err":"Get \"http://localhost:88888/api/v1/customers/CUSTOMER_1/payment_requests\": dial tcp: address 88888: invalid port"}`)
+	})
+
+	t.Run("When no parameters are provided", func(t *testing.T) {
+		c := qt.New(t)
+
+		server := lt.NewMockServer(c).
+			MatchMethod("GET").
+			MatchPath("/api/v1/customers/CUSTOMER_1/payment_requests").
+			MatchQuery("").
+			MockResponse(mockCustomerPaymentRequestListResponse)
+		defer server.Close()
+
+		result, err := server.Client().Customer().GetPaymentRequestList(context.Background(), "CUSTOMER_1", &CustomerPaymentRequestListInput{})
+		c.Assert(err == nil, qt.IsTrue)
+		c.Assert(result.PaymentRequests, qt.HasLen, 1)
+		c.Assert(result.Meta.CurrentPage, qt.Equals, 1)
+		c.Assert(result.Meta.TotalCount, qt.Equals, 1)
+	})
+
+	t.Run("When parameters are provided", func(t *testing.T) {
+		c := qt.New(t)
+
+		server := lt.NewMockServer(c).
+			MatchMethod("GET").
+			MatchPath("/api/v1/customers/CUSTOMER_1/payment_requests").
+			MatchQuery("per_page=10&page=1&payment_status=pending").
+			MockResponse(mockCustomerPaymentRequestListResponse)
+		defer server.Close()
+
+		perPage := 10
+		page := 1
+		result, err := server.Client().Customer().GetPaymentRequestList(context.Background(), "CUSTOMER_1", &CustomerPaymentRequestListInput{
+			PerPage:       &perPage,
+			Page:          &page,
+			PaymentStatus: "pending",
+		})
+		c.Assert(err == nil, qt.IsTrue)
+		c.Assert(result.PaymentRequests, qt.HasLen, 1)
+	})
+}
+
+func TestCustomerGetAppliedCouponList(t *testing.T) {
+	t.Run("When the server is not reachable", func(t *testing.T) {
+		c := qt.New(t)
+
+		client := New().SetBaseURL("http://localhost:88888").SetApiKey("test_api_key")
+		result, err := client.Customer().GetAppliedCouponList(context.Background(), "CUSTOMER_1", &CustomerAppliedCouponListInput{})
+		c.Assert(result, qt.IsNil)
+		c.Assert(err.Error(), qt.Equals, `{"status":0,"error":"","code":"","err":"Get \"http://localhost:88888/api/v1/customers/CUSTOMER_1/applied_coupons\": dial tcp: address 88888: invalid port"}`)
+	})
+
+	t.Run("When no parameters are provided", func(t *testing.T) {
+		c := qt.New(t)
+
+		server := lt.NewMockServer(c).
+			MatchMethod("GET").
+			MatchPath("/api/v1/customers/CUSTOMER_1/applied_coupons").
+			MatchQuery("").
+			MockResponse(mockCustomerAppliedCouponListResponse)
+		defer server.Close()
+
+		result, err := server.Client().Customer().GetAppliedCouponList(context.Background(), "CUSTOMER_1", &CustomerAppliedCouponListInput{})
+		c.Assert(err == nil, qt.IsTrue)
+		c.Assert(result.AppliedCoupons, qt.HasLen, 1)
+		c.Assert(result.Meta.CurrentPage, qt.Equals, 1)
+		c.Assert(result.Meta.TotalCount, qt.Equals, 1)
+	})
+
+	t.Run("When parameters are provided", func(t *testing.T) {
+		c := qt.New(t)
+
+		server := lt.NewMockServer(c).
+			MatchMethod("GET").
+			MatchPath("/api/v1/customers/CUSTOMER_1/applied_coupons").
+			MatchQuery("per_page=10&page=1&status=active&coupon_code[]=COUPON1&coupon_code[]=COUPON2").
+			MockResponse(mockCustomerAppliedCouponListResponse)
+		defer server.Close()
+
+		perPage := 10
+		page := 1
+		result, err := server.Client().Customer().GetAppliedCouponList(context.Background(), "CUSTOMER_1", &CustomerAppliedCouponListInput{
+			PerPage:    &perPage,
+			Page:       &page,
+			Status:     AppliedCouponStatusActive,
+			CouponCode: []string{"COUPON1", "COUPON2"},
+		})
+		c.Assert(err == nil, qt.IsTrue)
+		c.Assert(result.AppliedCoupons, qt.HasLen, 1)
+	})
+}
+
+func TestCustomerGetSubscriptionList(t *testing.T) {
+	t.Run("When the server is not reachable", func(t *testing.T) {
+		c := qt.New(t)
+
+		client := New().SetBaseURL("http://localhost:88888").SetApiKey("test_api_key")
+		result, err := client.Customer().GetSubscriptionList(context.Background(), "CUSTOMER_1", &CustomerSubscriptionListInput{})
+		c.Assert(result, qt.IsNil)
+		c.Assert(err.Error(), qt.Equals, `{"status":0,"error":"","code":"","err":"Get \"http://localhost:88888/api/v1/customers/CUSTOMER_1/subscriptions\": dial tcp: address 88888: invalid port"}`)
+	})
+
+	t.Run("When no parameters are provided", func(t *testing.T) {
+		c := qt.New(t)
+
+		server := lt.NewMockServer(c).
+			MatchMethod("GET").
+			MatchPath("/api/v1/customers/CUSTOMER_1/subscriptions").
+			MatchQuery("").
+			MockResponse(mockCustomerSubscriptionListResponse)
+		defer server.Close()
+
+		result, err := server.Client().Customer().GetSubscriptionList(context.Background(), "CUSTOMER_1", &CustomerSubscriptionListInput{})
+		c.Assert(err == nil, qt.IsTrue)
+		c.Assert(result.Subscriptions, qt.HasLen, 1)
+		c.Assert(result.Meta.CurrentPage, qt.Equals, 1)
+		c.Assert(result.Meta.TotalCount, qt.Equals, 1)
+	})
+
+	t.Run("When parameters are provided", func(t *testing.T) {
+		c := qt.New(t)
+
+		server := lt.NewMockServer(c).
+			MatchMethod("GET").
+			MatchPath("/api/v1/customers/CUSTOMER_1/subscriptions").
+			MatchQuery("per_page=10&page=1&plan_code=premium&status[]=active&status[]=terminated").
+			MockResponse(mockCustomerSubscriptionListResponse)
+		defer server.Close()
+
+		perPage := 10
+		page := 1
+		result, err := server.Client().Customer().GetSubscriptionList(context.Background(), "CUSTOMER_1", &CustomerSubscriptionListInput{
+			PerPage:  &perPage,
+			Page:     &page,
+			PlanCode: "premium",
+			Status:   []SubscriptionStatus{SubscriptionStatusActive, SubscriptionStatusTerminated},
+		})
+		c.Assert(err == nil, qt.IsTrue)
+		c.Assert(result.Subscriptions, qt.HasLen, 1)
+	})
+}

--- a/error_test.go
+++ b/error_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestErrorErr(t *testing.T) {
+func TestError_Err(t *testing.T) {
 	var hasErr error = Error{
 		Err:            errors.New("type assertion failed"),
 		HTTPStatusCode: 422,
@@ -15,7 +15,7 @@ func TestErrorErr(t *testing.T) {
 	t.Logf("%s", hasErr.Error())
 }
 
-func TestErrorNoErr(t *testing.T) {
+func TestError_NoErr(t *testing.T) {
 	var noErr error = Error{
 		HTTPStatusCode: 500,
 		Message:        "500",
@@ -23,7 +23,7 @@ func TestErrorNoErr(t *testing.T) {
 	t.Logf("%s", noErr.Error())
 }
 
-func TestErrorDetails(t *testing.T) {
+func TestError_Details(t *testing.T) {
 	var tests = []struct {
 		name  string
 		input string

--- a/event_test.go
+++ b/event_test.go
@@ -46,7 +46,7 @@ func assertBatchEventListResponse(c *qt.C, result []Event) {
 	c.Assert(event.CreatedAt.Format(time.RFC3339), qt.Equals, "2025-07-03T15:35:22Z")
 }
 
-func TestEventsBatch(t *testing.T) {
+func TestEventRequest_Batch(t *testing.T) {
 	t.Run("When the server is not reachable", func(t *testing.T) {
 		c := qt.New(t)
 

--- a/invoice_test.go
+++ b/invoice_test.go
@@ -226,7 +226,7 @@ func assertPaymentUrlResponse(c *qt.C, result *InvoicePaymentDetails) {
 	c.Assert(result.PaymentUrl, qt.Equals, "https://example.com/payment")
 }
 
-func TestInvoiceGetList(t *testing.T) {
+func TestInvoiceRequest_GetList(t *testing.T) {
 	t.Run("When the server is not reachable", func(t *testing.T) {
 		c := qt.New(t)
 
@@ -314,7 +314,7 @@ func TestInvoiceGetList(t *testing.T) {
 	})
 }
 
-func TestPaymentUrl(t *testing.T) {
+func TestInvoiceRequest_PaymentUrl(t *testing.T) {
 	t.Run("When the server is not reachable", func(t *testing.T) {
 		c := qt.New(t)
 

--- a/payment_request_test.go
+++ b/payment_request_test.go
@@ -61,7 +61,7 @@ func assertPaymentRequestResponse(c *qt.C, result *PaymentRequest) {
 	c.Assert(invoice.LagoID.String(), qt.Equals, "f8e194df-5d90-4382-b146-c881d2c67f28")
 }
 
-func TestPaymentRequestGet(t *testing.T) {
+func TestPaymentRequestRequest_Get(t *testing.T) {
 	t.Run("When the server is not reachable", func(t *testing.T) {
 		c := qt.New(t)
 

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -252,7 +252,7 @@ func terminateSubscription(c *qt.C, server *lt.MockServer, input SubscriptionTer
 	return subscription
 }
 
-func TestSubscriptionTerminate(t *testing.T) {
+func TestSubscriptionRequest_Terminate(t *testing.T) {
 	t.Run("When the server is not reachable", func(t *testing.T) {
 		c := qt.New(t)
 

--- a/wallet_transaction_test.go
+++ b/wallet_transaction_test.go
@@ -40,7 +40,7 @@ var mockWalletTransactionListResponse = `{
 			}
 		}`
 
-func TestWalletTransaction_Create(t *testing.T) {
+func TestWalletTransactionRequest_Create(t *testing.T) {
 	t.Run("When the server is not reachable", func(t *testing.T) {
 		c := qt.New(t)
 


### PR DESCRIPTION
## Context

This PR follows a critical issue on the `GET /api/v1/invoices` when requests were filtered by `external_customer_id` from the GO SDK client. See https://github.com/getlago/lago-go-client/pull/288

A new set of endpoints have been added to retrieve resources scoped to a specific customer.

## Description

This PR adds the clients for all the newly created routes:
- `/api/v1/customers/:customer_external_id/applied_coupons`
- `/api/v1/customers/:customer_external_id/credit_notes`
- `/api/v1/customers/:customer_external_id/invoices`
- `/api/v1/customers/:customer_external_id/payment_requests`
- `/api/v1/customers/:customer_external_id/payments`
- `/api/v1/customers/:customer_external_id/subscriptions`
- `/api/v1/customers/:customer_external_id/wallets`

Related to:
- https://github.com/getlago/lago-api/pull/4290
- https://github.com/getlago/lago-api/pull/4293
- https://github.com/getlago/lago-api/pull/4294
- https://github.com/getlago/lago-api/pull/4295
- https://github.com/getlago/lago-api/pull/4297
- https://github.com/getlago/lago-api/pull/4298
- https://github.com/getlago/lago-api/pull/4299
- https://github.com/getlago/lago-openapi/pull/448