### PR TITLE
fix(customer): Remove unnecessary filters on customer scoped routes

### DIFF
--- a/customer.go
+++ b/customer.go
@@ -324,9 +324,7 @@ type CustomerInvoiceListInput struct {
 	AmountFrom *int `url:"amount_from,omitempty"`
 	AmountTo   *int `url:"amount_to,omitempty"`
 
-	SearchTerm       string      `url:"search_term,omitempty"`
-	BillingEntityIDs []uuid.UUID `url:"billing_entity_ids[],omitempty"`
-	Currency         Currency    `url:"currency,omitempty"`
+	SearchTerm string `url:"search_term,omitempty"`
 }
 
 type CustomerCreditNoteListInput struct {
@@ -339,14 +337,12 @@ type CustomerCreditNoteListInput struct {
 	AmountFrom int `url:"amount_from,omitempty,string"`
 	AmountTo   int `url:"amount_to,omitempty,string"`
 
-	SearchTerm       string                 `url:"search_term,omitempty"`
-	BillingEntityIDs []uuid.UUID            `url:"billing_entity_ids[],omitempty"`
-	CreditStatus     CreditNoteCreditStatus `url:"credit_status,omitempty"`
-	Currency         Currency               `url:"currency,omitempty"`
-	InvoiceNumber    string                 `url:"invoice_number,omitempty"`
-	Reason           CreditNoteReason       `url:"reason,omitempty"`
-	RefundStatus     CreditNoteRefundStatus `url:"refund_status,omitempty"`
-	SelfBilled       *bool                  `url:"self_billed,omitempty,string"`
+	SearchTerm    string                 `url:"search_term,omitempty"`
+	CreditStatus  CreditNoteCreditStatus `url:"credit_status,omitempty"`
+	InvoiceNumber string                 `url:"invoice_number,omitempty"`
+	Reason        CreditNoteReason       `url:"reason,omitempty"`
+	RefundStatus  CreditNoteRefundStatus `url:"refund_status,omitempty"`
+	SelfBilled    *bool                  `url:"self_billed,omitempty,string"`
 }
 
 type CustomerPaymentListInput struct {

--- a/customer_test.go
+++ b/customer_test.go
@@ -226,7 +226,7 @@ func TestCustomerRequest_GetInvoiceList(t *testing.T) {
 		server := lt.NewMockServer(c).
 			MatchMethod("GET").
 			MatchPath("/api/v1/customers/CUSTOMER_1/invoices").
-			MatchQuery("per_page=10&page=1&issuing_date_from=2022-01-01&issuing_date_to=2022-12-31&invoice_type=subscription&status=finalized&payment_status=succeeded&payment_overdue=true&partially_paid=false&self_billed=true&payment_dispute_lost=false&amount_from=100&amount_to=1000&search_term=test&currency=EUR").
+			MatchQuery("per_page=10&page=1&issuing_date_from=2022-01-01&issuing_date_to=2022-12-31&invoice_type=subscription&status=finalized&payment_status=succeeded&payment_overdue=true&partially_paid=false&self_billed=true&payment_dispute_lost=false&amount_from=100&amount_to=1000&search_term=test").
 			MockResponse(mockCustomerInvoiceListResponse)
 		defer server.Close()
 
@@ -253,7 +253,6 @@ func TestCustomerRequest_GetInvoiceList(t *testing.T) {
 			AmountFrom:         &amountFrom,
 			AmountTo:           &amountTo,
 			SearchTerm:         "test",
-			Currency:           EUR,
 		})
 		c.Assert(err == nil, qt.IsTrue)
 		c.Assert(result.Invoices, qt.HasLen, 1)
@@ -301,7 +300,6 @@ func TestCustomerRequest_GetCreditNoteList(t *testing.T) {
 				"&amount_to=1000" +
 				"&search_term=test" +
 				"&credit_status=available" +
-				"&currency=EUR" +
 				"&invoice_number=INV-001" +
 				"&reason=duplicated_charge" +
 				"&refund_status=pending" +
@@ -321,7 +319,6 @@ func TestCustomerRequest_GetCreditNoteList(t *testing.T) {
 			AmountTo:        1000,
 			SearchTerm:      "test",
 			CreditStatus:    CreditNoteCreditStatusAvailable,
-			Currency:        EUR,
 			InvoiceNumber:   "INV-001",
 			Reason:          CreditNoteReasonDuplicatedCharge,
 			RefundStatus:    CreditNoteRefundStatusPending,


### PR DESCRIPTION
# Context

A customer belongs to a single billing entity and cannot change its currency. So it does not make sense to filter customer resources by `billing_entity_ids` or `currency`.

# Description

This removes those unnecessary filters.