### PR TITLE
feat(customer): Add more filters to `GET /api/v1/customers`

### DIFF
--- a/customer_test.go
+++ b/customer_test.go
@@ -10,6 +10,150 @@ import (
 	lt "github.com/getlago/lago-go-client/testing"
 )
 
+// Mock response for customer list
+var mockCustomerListResponse = `{
+	"customers": [
+		{
+			"lago_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
+			"sequential_id": 1,
+			"slug": "LAG-1234-001",
+			"external_id": "CUSTOMER_1",
+			"billing_entity_code": "acme_corp",
+			"name": "John Doe",
+			"firstname": "John",
+			"lastname": "Doe",
+			"customer_type": "company",
+			"email": "customer@example.com",
+			"address_line1": "5230 Penfield Ave",
+			"address_line2": null,
+			"city": "Woodland Hills",
+			"state": "CA",
+			"zipcode": "91364",
+			"country": "US",
+			"legal_name": "Acme Corp",
+			"legal_number": "123456789",
+			"net_payment_term": 30,
+			"tax_identification_number": "US123456789",
+			"logo_url": "https://getlago.com/logo.png",
+			"phone": "+1-555-123-4567",
+			"url": "https://acme.com",
+			"finalize_zero_amount_invoice": "finalize",
+			"billing_configuration": {
+				"invoice_grace_period": 3,
+				"payment_provider": "stripe",
+				"payment_provider_code": "stripe_123",
+				"provider_customer_id": "cus_123456",
+				"sync_with_provider": true,
+				"document_locale": "en",
+				"provider_payment_methods": ["card", "sepa_debit"]
+			},
+			"shipping_address": {
+				"address_line1": "123 Shipping St",
+				"address_line2": "Suite 456",
+				"city": "Shipping City",
+				"zipcode": "12345",
+				"state": "NY",
+				"country": "US"
+			},
+			"integration_customers": [
+				{
+					"lago_id": "2b902b90-2b90-2b90-2b90-2b902b902b90",
+					"external_customer_id": "netsuite_123",
+					"type": "netsuite",
+					"integration_code": "netsuite_integration",
+					"subsidiary_id": "sub_123",
+					"sync_with_provider": true
+				}
+			],
+			"metadata": [
+				{
+					"lago_id": "3c903c90-3c90-3c90-3c90-3c903c903c90",
+					"key": "department",
+					"value": "engineering",
+					"display_in_invoice": true,
+					"created_at": "2022-04-29T08:59:51Z"
+				}
+			],
+			"currency": "USD",
+			"timezone": "America/New_York",
+			"applicable_timezone": "America/New_York",
+			"skip_invoice_custom_sections": false,
+			"taxes": [],
+			"applicable_invoice_custom_sections": [],
+			"created_at": "2022-04-29T08:59:51Z",
+			"updated_at": "2022-04-29T08:59:51Z"
+		},
+		{
+			"lago_id": "2b902b90-2b90-2b90-2b90-2b902b902b90",
+			"sequential_id": 2,
+			"slug": "LAG-1234-002",
+			"external_id": "CUSTOMER_2",
+			"billing_entity_code": "acme_corp",
+			"name": "Jane Smith",
+			"firstname": "Jane",
+			"lastname": "Smith",
+			"customer_type": "individual",
+			"email": "jane@example.com",
+			"address_line1": "456 Oak Street",
+			"address_line2": "Apt 789",
+			"city": "San Francisco",
+			"state": "CA",
+			"zipcode": "94102",
+			"country": "US",
+			"legal_name": "Jane Smith",
+			"legal_number": "987654321",
+			"net_payment_term": 15,
+			"tax_identification_number": "US987654321",
+			"logo_url": null,
+			"phone": "+1-555-987-6543",
+			"url": "https://janesmith.com",
+			"finalize_zero_amount_invoice": "skip",
+			"billing_configuration": {
+				"invoice_grace_period": 5,
+				"payment_provider": "adyen",
+				"payment_provider_code": "adyen_456",
+				"provider_customer_id": "adyen_customer_789",
+				"sync_with_provider": false,
+				"document_locale": "fr",
+				"provider_payment_methods": ["card", "us_bank_account"]
+			},
+			"shipping_address": {
+				"address_line1": "789 Delivery Ave",
+				"address_line2": null,
+				"city": "Delivery City",
+				"zipcode": "54321",
+				"state": "TX",
+				"country": "US"
+			},
+			"integration_customers": [],
+			"metadata": [
+				{
+					"lago_id": "4d904d90-4d90-4d90-4d90-4d904d904d90",
+					"key": "segment",
+					"value": "enterprise",
+					"display_in_invoice": false,
+					"created_at": "2022-04-29T08:59:51Z"
+				}
+			],
+			"currency": "EUR",
+			"timezone": "Europe/Paris",
+			"applicable_timezone": "Europe/Paris",
+			"skip_invoice_custom_sections": true,
+			"taxes": [],
+			"applicable_invoice_custom_sections": [],
+			"created_at": "2022-04-29T08:59:51Z",
+			"updated_at": "2022-04-29T08:59:51Z"
+		}
+	],
+	"meta": {
+		"current_page": 1,
+		"next_page": 0,
+		"prev_page": 0,
+		"total_pages": 1,
+		"total_count": 2
+	}
+}`
+
 // Mock response for customer invoice list
 var mockCustomerInvoiceListResponse = map[string]any{
 	"invoices": []map[string]interface{}{
@@ -524,5 +668,121 @@ func TestCustomerRequest_GetSubscriptionList(t *testing.T) {
 		})
 		c.Assert(err == nil, qt.IsTrue)
 		c.Assert(result.Subscriptions, qt.HasLen, 1)
+	})
+}
+
+func TestCustomerRequest_GetList(t *testing.T) {
+	t.Run("When the server is not reachable", func(t *testing.T) {
+		c := qt.New(t)
+
+		client := New().SetBaseURL("http://localhost:88888").SetApiKey("test_api_key")
+		result, err := client.Customer().GetList(context.Background(), &CustomerListInput{})
+		c.Assert(result, qt.IsNil)
+		c.Assert(err.Error(), qt.Equals, `{"status":0,"error":"","code":"","err":"Get \"http://localhost:88888/api/v1/customers\": dial tcp: address 88888: invalid port"}`)
+	})
+
+	t.Run("When no parameters are provided", func(t *testing.T) {
+		c := qt.New(t)
+
+		server := lt.NewMockServer(c).
+			MatchMethod("GET").
+			MatchPath("/api/v1/customers").
+			MatchQuery("").
+			MockResponse(mockCustomerListResponse)
+		defer server.Close()
+
+		result, err := server.Client().Customer().GetList(context.Background(), &CustomerListInput{})
+		c.Assert(err == nil, qt.IsTrue)
+		c.Assert(result.Customers, qt.HasLen, 2)
+		c.Assert(result.Meta.CurrentPage, qt.Equals, 1)
+		c.Assert(result.Meta.TotalCount, qt.Equals, 2)
+
+		// Verify first customer data
+		firstCustomer := result.Customers[0]
+		c.Assert(firstCustomer.ExternalID, qt.Equals, "CUSTOMER_1")
+		c.Assert(firstCustomer.Name, qt.Equals, "John Doe")
+		c.Assert(firstCustomer.Email, qt.Equals, "customer@example.com")
+		c.Assert(firstCustomer.CustomerType, qt.Equals, "company")
+
+		// Verify second customer data
+		secondCustomer := result.Customers[1]
+		c.Assert(secondCustomer.ExternalID, qt.Equals, "CUSTOMER_2")
+		c.Assert(secondCustomer.Name, qt.Equals, "Jane Smith")
+		c.Assert(secondCustomer.Email, qt.Equals, "jane@example.com")
+		c.Assert(secondCustomer.CustomerType, qt.Equals, "individual")
+	})
+
+	t.Run("When all parameters are provided including search_term", func(t *testing.T) {
+		c := qt.New(t)
+
+		server := lt.NewMockServer(c).
+			MatchMethod("GET").
+			MatchPath("/api/v1/customers").
+			MatchQuery("per_page=5" +
+				"&page=1" +
+				"&search_term=acme" +
+				"&countries[]=US" +
+				"&countries[]=CA" +
+				"&states[]=CA" +
+				"&states[]=NY" +
+				"&zipcodes[]=91364" +
+				"&zipcodes[]=94102" +
+				"&currencies[]=USD" +
+				"&currencies[]=EUR" +
+				"&has_tax_identification_number=true" +
+				"&customer_type=company" +
+				"&has_customer_type=false" +
+				"&metadata[department]=engineering" +
+				"&metadata[segment]=enterprise").
+			MockResponse(mockCustomerListResponse)
+		defer server.Close()
+
+		perPage := 5
+		page := 1
+		hasTaxId := true
+		hasCustomerType := false
+		metadata := CustomerListInputMetadata{
+			"department": "engineering",
+			"segment":    "enterprise",
+		}
+
+		result, err := server.Client().Customer().GetList(context.Background(), &CustomerListInput{
+			PerPage:                    &perPage,
+			Page:                       &page,
+			SearchTerm:                 "acme",
+			Countries:                  []string{"US", "CA"},
+			States:                     []string{"CA", "NY"},
+			Zipcodes:                   []string{"91364", "94102"},
+			Currencies:                 []Currency{USD, EUR},
+			HasTaxIdentificationNumber: &hasTaxId,
+			CustomerType:               CompanyCustomerType,
+			HasCustomerType:            &hasCustomerType,
+			Metadata:                   metadata,
+		})
+		c.Assert(err == nil, qt.IsTrue)
+		c.Assert(result.Customers, qt.HasLen, 2)
+		c.Assert(result.Meta.CurrentPage, qt.Equals, 1)
+		c.Assert(result.Meta.TotalCount, qt.Equals, 2)
+
+		// Verify first customer data
+		firstCustomer := result.Customers[0]
+		c.Assert(firstCustomer.ExternalID, qt.Equals, "CUSTOMER_1")
+		c.Assert(firstCustomer.Name, qt.Equals, "John Doe")
+		c.Assert(firstCustomer.Email, qt.Equals, "customer@example.com")
+		c.Assert(firstCustomer.CustomerType, qt.Equals, "company")
+
+		// Verify second customer data
+		secondCustomer := result.Customers[1]
+		c.Assert(secondCustomer.ExternalID, qt.Equals, "CUSTOMER_2")
+		c.Assert(secondCustomer.Name, qt.Equals, "Jane Smith")
+		c.Assert(secondCustomer.Email, qt.Equals, "jane@example.com")
+		c.Assert(secondCustomer.CustomerType, qt.Equals, "individual")
+
+		// Verify the response structure
+		for _, customer := range result.Customers {
+			c.Assert(customer.LagoID, qt.Not(qt.Equals), "")
+			c.Assert(customer.ExternalID, qt.Not(qt.Equals), "")
+			c.Assert(customer.Name, qt.Not(qt.Equals), "")
+		}
 	})
 }


### PR DESCRIPTION
## Context

The filtering on the `GET /api/v1/customers` endpoint was too limited so we added a few filters:

- https://github.com/getlago/lago-api/pull/4377
- https://github.com/getlago/lago-api/pull/4378
- https://github.com/getlago/lago-api/pull/4383
- https://github.com/getlago/lago-api/pull/4386
- https://github.com/getlago/lago-api/pull/4392
- https://github.com/getlago/lago-api/pull/4393

## Description

This implements those filters on the client.