### PR TITLE
feat(api): Update AppliedInvoiceCustomSection to use nested InvoiceCu…

### DIFF
--- a/customer_wallet_test.go
+++ b/customer_wallet_test.go
@@ -52,8 +52,12 @@ var mockCustomerWalletResponse = `{
 			},
 			"applied_invoice_custom_sections": [{
 				"lago_id": "d1d2e3e4-f5f6-7890-1234-56789abcdef0",
-				"invoice_custom_section_id": "a1a2b3b4-c5d6-7890-1234-56789abcdef0",
-				"created_at": "2022-04-29T08:59:51Z"
+				"created_at": "2022-04-29T08:59:51Z",
+				"invoice_custom_section": {
+					"lago_id": "a1a2b3b4-c5d6-7890-1234-56789abcdef0",
+					"code": "rule_section_code",
+					"name": "Rule Section Name"
+				}
 			}]
 		}],
 		"applies_to": {
@@ -66,8 +70,12 @@ var mockCustomerWalletResponse = `{
 		},
 		"applied_invoice_custom_sections": [{
 			"lago_id": "e1e2f3f4-a5b6-7890-1234-56789abcdef0",
-			"invoice_custom_section_id": "b2b3c4c5-d6e7-8901-2345-6789abcdef01",
-			"created_at": "2022-04-29T08:59:51Z"
+			"created_at": "2022-04-29T08:59:51Z",
+			"invoice_custom_section": {
+				"lago_id": "b2b3c4c5-d6e7-8901-2345-6789abcdef01",
+				"code": "wallet_section_code",
+				"name": "Wallet Section Name"
+			}
 		}]
 	}
 }`
@@ -311,7 +319,8 @@ func TestCustomerWallet_Get(t *testing.T) {
 		c.Assert(result.AppliesTo.BillableMetricCodes, qt.DeepEquals, []string{"bm1"})
 		c.Assert(result.AppliedInvoiceCustomSections, qt.HasLen, 1)
 		c.Assert(result.AppliedInvoiceCustomSections[0].LagoId, qt.Equals, uuid.MustParse("e1e2f3f4-a5b6-7890-1234-56789abcdef0"))
-		c.Assert(result.AppliedInvoiceCustomSections[0].InvoiceCustomSectionId, qt.Equals, uuid.MustParse("b2b3c4c5-d6e7-8901-2345-6789abcdef01"))
+		c.Assert(result.AppliedInvoiceCustomSections[0].InvoiceCustomSection.LagoId, qt.Equals, uuid.MustParse("b2b3c4c5-d6e7-8901-2345-6789abcdef01"))
+		c.Assert(result.AppliedInvoiceCustomSections[0].InvoiceCustomSection.Name, qt.Equals, "Wallet Section Name")
 	})
 }
 

--- a/customer_wallet_test.go
+++ b/customer_wallet_test.go
@@ -52,6 +52,7 @@ var mockCustomerWalletResponse = `{
 			},
 			"applied_invoice_custom_sections": [{
 				"lago_id": "d1d2e3e4-f5f6-7890-1234-56789abcdef0",
+				"invoice_custom_section_id": "a1a2b3b4-c5d6-7890-1234-56789abcdef0",
 				"created_at": "2022-04-29T08:59:51Z",
 				"invoice_custom_section": {
 					"lago_id": "a1a2b3b4-c5d6-7890-1234-56789abcdef0",
@@ -70,6 +71,7 @@ var mockCustomerWalletResponse = `{
 		},
 		"applied_invoice_custom_sections": [{
 			"lago_id": "e1e2f3f4-a5b6-7890-1234-56789abcdef0",
+			"invoice_custom_section_id": "b2b3c4c5-d6e7-8901-2345-6789abcdef01",
 			"created_at": "2022-04-29T08:59:51Z",
 			"invoice_custom_section": {
 				"lago_id": "b2b3c4c5-d6e7-8901-2345-6789abcdef01",
@@ -315,10 +317,12 @@ func TestCustomerWallet_Get(t *testing.T) {
 		c.Assert(result.RecurringTransactionRules[0].IgnorePaidTopUpLimits, qt.Equals, false)
 		c.Assert(result.RecurringTransactionRules[0].AppliedInvoiceCustomSections, qt.HasLen, 1)
 		c.Assert(result.RecurringTransactionRules[0].AppliedInvoiceCustomSections[0].LagoId, qt.Equals, uuid.MustParse("d1d2e3e4-f5f6-7890-1234-56789abcdef0"))
+		c.Assert(result.RecurringTransactionRules[0].AppliedInvoiceCustomSections[0].InvoiceCustomSectionId, qt.Equals, uuid.MustParse("a1a2b3b4-c5d6-7890-1234-56789abcdef0"))
 		c.Assert(result.AppliesTo.FeeTypes, qt.DeepEquals, []string{"charge"})
 		c.Assert(result.AppliesTo.BillableMetricCodes, qt.DeepEquals, []string{"bm1"})
 		c.Assert(result.AppliedInvoiceCustomSections, qt.HasLen, 1)
 		c.Assert(result.AppliedInvoiceCustomSections[0].LagoId, qt.Equals, uuid.MustParse("e1e2f3f4-a5b6-7890-1234-56789abcdef0"))
+		c.Assert(result.AppliedInvoiceCustomSections[0].InvoiceCustomSectionId, qt.Equals, uuid.MustParse("b2b3c4c5-d6e7-8901-2345-6789abcdef01"))
 		c.Assert(result.AppliedInvoiceCustomSections[0].InvoiceCustomSection.LagoId, qt.Equals, uuid.MustParse("b2b3c4c5-d6e7-8901-2345-6789abcdef01"))
 		c.Assert(result.AppliedInvoiceCustomSections[0].InvoiceCustomSection.Name, qt.Equals, "Wallet Section Name")
 	})

--- a/invoice_custom_section.go
+++ b/invoice_custom_section.go
@@ -21,7 +21,8 @@ type InvoiceCustomSectionInput struct {
 }
 
 type AppliedInvoiceCustomSection struct {
-	LagoId               uuid.UUID            `json:"lago_id,omitempty"`
-	CreatedAt            time.Time            `json:"created_at,omitempty"`
-	InvoiceCustomSection InvoiceCustomSection `json:"invoice_custom_section,omitempty"`
+	LagoId                 uuid.UUID            `json:"lago_id,omitempty"`
+	InvoiceCustomSectionId uuid.UUID            `json:"invoice_custom_section_id,omitempty"`
+	CreatedAt              time.Time            `json:"created_at,omitempty"`
+	InvoiceCustomSection   InvoiceCustomSection `json:"invoice_custom_section,omitempty"`
 }

--- a/invoice_custom_section.go
+++ b/invoice_custom_section.go
@@ -21,7 +21,7 @@ type InvoiceCustomSectionInput struct {
 }
 
 type AppliedInvoiceCustomSection struct {
-	LagoId                 uuid.UUID `json:"lago_id,omitempty"`
-	InvoiceCustomSectionId uuid.UUID `json:"invoice_custom_section_id,omitempty"`
-	CreatedAt              time.Time `json:"created_at,omitempty"`
+	LagoId               uuid.UUID            `json:"lago_id,omitempty"`
+	CreatedAt            time.Time            `json:"created_at,omitempty"`
+	InvoiceCustomSection InvoiceCustomSection `json:"invoice_custom_section,omitempty"`
 }

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -45,8 +45,15 @@ var mockSubscriptionResponse = `{
     "applied_invoice_custom_sections": [
       {
         "lago_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
-        "invoice_custom_section_id": "2b902b90-2b90-2b90-2b90-2b902b902b90",
-        "created_at": "2022-08-08T00:00:00Z"
+        "created_at": "2022-08-08T00:00:00Z",
+        "invoice_custom_section": {
+          "lago_id": "2b902b90-2b90-2b90-2b90-2b902b902b90",
+          "code": "section_code",
+          "name": "Section Name",
+          "description": "Section description",
+          "details": "Section details",
+          "display_name": "Display Name"
+        }
       }
     ],
     "plan": {
@@ -434,7 +441,9 @@ func TestSubscriptionRequest_CreateWithPaymentMethod(t *testing.T) {
 		c.Assert(subscription.PaymentMethod.PaymentMethodID, qt.Equals, "pm_123456")
 		c.Assert(subscription.AppliedInvoiceCustomSections, qt.HasLen, 1)
 		c.Assert(subscription.AppliedInvoiceCustomSections[0].LagoId.String(), qt.Equals, "1a901a90-1a90-1a90-1a90-1a901a901a90")
-		c.Assert(subscription.AppliedInvoiceCustomSections[0].InvoiceCustomSectionId.String(), qt.Equals, "2b902b90-2b90-2b90-2b90-2b902b902b90")
+		c.Assert(subscription.AppliedInvoiceCustomSections[0].InvoiceCustomSection.LagoId.String(), qt.Equals, "2b902b90-2b90-2b90-2b90-2b902b902b90")
+		c.Assert(subscription.AppliedInvoiceCustomSections[0].InvoiceCustomSection.Name, qt.Equals, "Section Name")
+		c.Assert(subscription.AppliedInvoiceCustomSections[0].InvoiceCustomSection.Code, qt.Equals, "section_code")
 	})
 }
 
@@ -476,6 +485,7 @@ func TestSubscriptionRequest_CreateWithInvoiceCustomSections(t *testing.T) {
 		c.Assert(err == nil, qt.IsTrue)
 		c.Assert(subscription.AppliedInvoiceCustomSections, qt.HasLen, 1)
 		c.Assert(subscription.AppliedInvoiceCustomSections[0].LagoId.String(), qt.Equals, "1a901a90-1a90-1a90-1a90-1a901a901a90")
+		c.Assert(subscription.AppliedInvoiceCustomSections[0].InvoiceCustomSection.Name, qt.Equals, "Section Name")
 	})
 }
 

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -45,6 +45,7 @@ var mockSubscriptionResponse = `{
     "applied_invoice_custom_sections": [
       {
         "lago_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
+        "invoice_custom_section_id": "2b902b90-2b90-2b90-2b90-2b902b902b90",
         "created_at": "2022-08-08T00:00:00Z",
         "invoice_custom_section": {
           "lago_id": "2b902b90-2b90-2b90-2b90-2b902b902b90",
@@ -441,6 +442,7 @@ func TestSubscriptionRequest_CreateWithPaymentMethod(t *testing.T) {
 		c.Assert(subscription.PaymentMethod.PaymentMethodID, qt.Equals, "pm_123456")
 		c.Assert(subscription.AppliedInvoiceCustomSections, qt.HasLen, 1)
 		c.Assert(subscription.AppliedInvoiceCustomSections[0].LagoId.String(), qt.Equals, "1a901a90-1a90-1a90-1a90-1a901a901a90")
+		c.Assert(subscription.AppliedInvoiceCustomSections[0].InvoiceCustomSectionId.String(), qt.Equals, "2b902b90-2b90-2b90-2b90-2b902b902b90")
 		c.Assert(subscription.AppliedInvoiceCustomSections[0].InvoiceCustomSection.LagoId.String(), qt.Equals, "2b902b90-2b90-2b90-2b90-2b902b902b90")
 		c.Assert(subscription.AppliedInvoiceCustomSections[0].InvoiceCustomSection.Name, qt.Equals, "Section Name")
 		c.Assert(subscription.AppliedInvoiceCustomSections[0].InvoiceCustomSection.Code, qt.Equals, "section_code")
@@ -485,6 +487,7 @@ func TestSubscriptionRequest_CreateWithInvoiceCustomSections(t *testing.T) {
 		c.Assert(err == nil, qt.IsTrue)
 		c.Assert(subscription.AppliedInvoiceCustomSections, qt.HasLen, 1)
 		c.Assert(subscription.AppliedInvoiceCustomSections[0].LagoId.String(), qt.Equals, "1a901a90-1a90-1a90-1a90-1a901a901a90")
+		c.Assert(subscription.AppliedInvoiceCustomSections[0].InvoiceCustomSectionId.String(), qt.Equals, "2b902b90-2b90-2b90-2b90-2b902b902b90")
 		c.Assert(subscription.AppliedInvoiceCustomSections[0].InvoiceCustomSection.Name, qt.Equals, "Section Name")
 	})
 }

--- a/wallet_test.go
+++ b/wallet_test.go
@@ -55,8 +55,12 @@ var mockWalletResponse = `{
 			},
 			"applied_invoice_custom_sections": [{
 				"lago_id": "d1d2e3e4-f5f6-7890-1234-56789abcdef0",
-				"invoice_custom_section_id": "a1a2b3b4-c5d6-7890-1234-56789abcdef0",
-				"created_at": "2022-04-29T08:59:51Z"
+				"created_at": "2022-04-29T08:59:51Z",
+				"invoice_custom_section": {
+					"lago_id": "a1a2b3b4-c5d6-7890-1234-56789abcdef0",
+					"code": "rule_section_code",
+					"name": "Rule Section Name"
+				}
 			}]
 		}],
 		"applies_to": {
@@ -69,8 +73,12 @@ var mockWalletResponse = `{
 		},
 		"applied_invoice_custom_sections": [{
 			"lago_id": "e1e2f3f4-a5b6-7890-1234-56789abcdef0",
-			"invoice_custom_section_id": "b2b3c4c5-d6e7-8901-2345-6789abcdef01",
-			"created_at": "2022-04-29T08:59:51Z"
+			"created_at": "2022-04-29T08:59:51Z",
+			"invoice_custom_section": {
+				"lago_id": "b2b3c4c5-d6e7-8901-2345-6789abcdef01",
+				"code": "wallet_section_code",
+				"name": "Wallet Section Name"
+			}
 		}]
 	}
 }`
@@ -316,7 +324,8 @@ func TestWallet_Get(t *testing.T) {
 		c.Assert(result.AppliesTo.BillableMetricCodes, qt.DeepEquals, []string{"bm1"})
 		c.Assert(result.AppliedInvoiceCustomSections, qt.HasLen, 1)
 		c.Assert(result.AppliedInvoiceCustomSections[0].LagoId, qt.Equals, uuid.MustParse("e1e2f3f4-a5b6-7890-1234-56789abcdef0"))
-		c.Assert(result.AppliedInvoiceCustomSections[0].InvoiceCustomSectionId, qt.Equals, uuid.MustParse("b2b3c4c5-d6e7-8901-2345-6789abcdef01"))
+		c.Assert(result.AppliedInvoiceCustomSections[0].InvoiceCustomSection.LagoId, qt.Equals, uuid.MustParse("b2b3c4c5-d6e7-8901-2345-6789abcdef01"))
+		c.Assert(result.AppliedInvoiceCustomSections[0].InvoiceCustomSection.Name, qt.Equals, "Wallet Section Name")
 	})
 }
 

--- a/wallet_test.go
+++ b/wallet_test.go
@@ -55,6 +55,7 @@ var mockWalletResponse = `{
 			},
 			"applied_invoice_custom_sections": [{
 				"lago_id": "d1d2e3e4-f5f6-7890-1234-56789abcdef0",
+				"invoice_custom_section_id": "a1a2b3b4-c5d6-7890-1234-56789abcdef0",
 				"created_at": "2022-04-29T08:59:51Z",
 				"invoice_custom_section": {
 					"lago_id": "a1a2b3b4-c5d6-7890-1234-56789abcdef0",
@@ -73,6 +74,7 @@ var mockWalletResponse = `{
 		},
 		"applied_invoice_custom_sections": [{
 			"lago_id": "e1e2f3f4-a5b6-7890-1234-56789abcdef0",
+			"invoice_custom_section_id": "b2b3c4c5-d6e7-8901-2345-6789abcdef01",
 			"created_at": "2022-04-29T08:59:51Z",
 			"invoice_custom_section": {
 				"lago_id": "b2b3c4c5-d6e7-8901-2345-6789abcdef01",
@@ -320,10 +322,12 @@ func TestWallet_Get(t *testing.T) {
 		c.Assert(result.RecurringTransactionRules[0].IgnorePaidTopUpLimits, qt.Equals, false)
 		c.Assert(result.RecurringTransactionRules[0].AppliedInvoiceCustomSections, qt.HasLen, 1)
 		c.Assert(result.RecurringTransactionRules[0].AppliedInvoiceCustomSections[0].LagoId, qt.Equals, uuid.MustParse("d1d2e3e4-f5f6-7890-1234-56789abcdef0"))
+		c.Assert(result.RecurringTransactionRules[0].AppliedInvoiceCustomSections[0].InvoiceCustomSectionId, qt.Equals, uuid.MustParse("a1a2b3b4-c5d6-7890-1234-56789abcdef0"))
 		c.Assert(result.AppliesTo.FeeTypes, qt.DeepEquals, []string{"charge"})
 		c.Assert(result.AppliesTo.BillableMetricCodes, qt.DeepEquals, []string{"bm1"})
 		c.Assert(result.AppliedInvoiceCustomSections, qt.HasLen, 1)
 		c.Assert(result.AppliedInvoiceCustomSections[0].LagoId, qt.Equals, uuid.MustParse("e1e2f3f4-a5b6-7890-1234-56789abcdef0"))
+		c.Assert(result.AppliedInvoiceCustomSections[0].InvoiceCustomSectionId, qt.Equals, uuid.MustParse("b2b3c4c5-d6e7-8901-2345-6789abcdef01"))
 		c.Assert(result.AppliedInvoiceCustomSections[0].InvoiceCustomSection.LagoId, qt.Equals, uuid.MustParse("b2b3c4c5-d6e7-8901-2345-6789abcdef01"))
 		c.Assert(result.AppliedInvoiceCustomSections[0].InvoiceCustomSection.Name, qt.Equals, "Wallet Section Name")
 	})

--- a/wallet_transaction_test.go
+++ b/wallet_transaction_test.go
@@ -43,6 +43,7 @@ var mockWalletTransactionListResponse = `{
 				},
 				"applied_invoice_custom_sections": [{
 					"lago_id": "e1e2f3f4-a5b6-7890-1234-56789abcdef0",
+					"invoice_custom_section_id": "f1f2a3a4-b5c6-7890-1234-56789abcdef0",
 					"created_at": "2024-06-01T12:00:00Z",
 					"invoice_custom_section": {
 						"lago_id": "f1f2a3a4-b5c6-7890-1234-56789abcdef0",
@@ -133,8 +134,9 @@ func TestWalletTransactionRequest_Create(t *testing.T) {
 					},
 					AppliedInvoiceCustomSections: []AppliedInvoiceCustomSection{
 						{
-							LagoId:    uuid.MustParse("e1e2f3f4-a5b6-7890-1234-56789abcdef0"),
-							CreatedAt: time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC),
+							LagoId:                 uuid.MustParse("e1e2f3f4-a5b6-7890-1234-56789abcdef0"),
+							InvoiceCustomSectionId: uuid.MustParse("f1f2a3a4-b5c6-7890-1234-56789abcdef0"),
+							CreatedAt:              time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC),
 							InvoiceCustomSection: InvoiceCustomSection{
 								LagoId: uuid.MustParse("f1f2a3a4-b5c6-7890-1234-56789abcdef0"),
 								Code:   "wt_section_code",

--- a/wallet_transaction_test.go
+++ b/wallet_transaction_test.go
@@ -43,8 +43,12 @@ var mockWalletTransactionListResponse = `{
 				},
 				"applied_invoice_custom_sections": [{
 					"lago_id": "e1e2f3f4-a5b6-7890-1234-56789abcdef0",
-					"invoice_custom_section_id": "f1f2a3a4-b5c6-7890-1234-56789abcdef0",
-					"created_at": "2024-06-01T12:00:00Z"
+					"created_at": "2024-06-01T12:00:00Z",
+					"invoice_custom_section": {
+						"lago_id": "f1f2a3a4-b5c6-7890-1234-56789abcdef0",
+						"code": "wt_section_code",
+						"name": "WT Section Name"
+					}
 				}]
 			}],
 			"meta": {
@@ -129,9 +133,13 @@ func TestWalletTransactionRequest_Create(t *testing.T) {
 					},
 					AppliedInvoiceCustomSections: []AppliedInvoiceCustomSection{
 						{
-							LagoId:                 uuid.MustParse("e1e2f3f4-a5b6-7890-1234-56789abcdef0"),
-							InvoiceCustomSectionId: uuid.MustParse("f1f2a3a4-b5c6-7890-1234-56789abcdef0"),
-							CreatedAt:              time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC),
+							LagoId:    uuid.MustParse("e1e2f3f4-a5b6-7890-1234-56789abcdef0"),
+							CreatedAt: time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC),
+							InvoiceCustomSection: InvoiceCustomSection{
+								LagoId: uuid.MustParse("f1f2a3a4-b5c6-7890-1234-56789abcdef0"),
+								Code:   "wt_section_code",
+								Name:   "WT Section Name",
+							},
 						},
 					},
 				},


### PR DESCRIPTION
## Summary                                                                                                                                                                                                         
  - Update `AppliedInvoiceCustomSection` struct to replace flat `InvoiceCustomSectionId` field with a nested `InvoiceCustomSection` struct containing `LagoId`, `Code`, `Name`, `Description`, `Details`, and        
  `DisplayName`                                                                                                                                                                                                      
  - Update JSON test fixtures for subscription, wallet, customer wallet, and wallet transaction to use the nested object format                                                                                      
  - Update test assertions across all four test files 