### PR TITLE
fix(api): Deprecate filter_by prefixed params on current usage

### DIFF
--- a/customer.go
+++ b/customer.go
@@ -330,10 +330,18 @@ type CustomerCheckoutUrl struct {
 type CustomerUsageInput struct {
 	ExternalSubscriptionID string            `json:"external_subscription_id,omitempty"`
 	ApplyTaxes             bool              `json:"apply_taxes,omitempty"`
-	FilterByChargeID       string            `json:"filter_by_charge_id,omitempty"`
-	FilterByChargeCode     string            `json:"filter_by_charge_code,omitempty"`
-	FilterByGroup          map[string]string `json:"filter_by_group,omitempty"`
+	ChargeID               string            `json:"charge_id,omitempty"`
+	ChargeCode             string            `json:"charge_code,omitempty"`
+	BillableMetricCode     string            `json:"billable_metric_code,omitempty"`
+	Group                  map[string]string `json:"group,omitempty"`
 	FullUsage              bool              `json:"full_usage,omitempty"`
+
+	// Deprecated: Use ChargeID instead.
+	FilterByChargeID string `json:"filter_by_charge_id,omitempty"`
+	// Deprecated: Use ChargeCode instead.
+	FilterByChargeCode string `json:"filter_by_charge_code,omitempty"`
+	// Deprecated: Use Group instead.
+	FilterByGroup map[string]string `json:"filter_by_group,omitempty"`
 }
 
 type CustomerPastUsageInput struct {
@@ -514,6 +522,18 @@ func (cr *CustomerRequest) CurrentUsage(ctx context.Context, externalCustomerID 
 		"apply_taxes":              strconv.FormatBool(customerUsageInput.ApplyTaxes),
 	}
 
+	if customerUsageInput.ChargeID != "" {
+		queryParams["charge_id"] = customerUsageInput.ChargeID
+	}
+	if customerUsageInput.ChargeCode != "" {
+		queryParams["charge_code"] = customerUsageInput.ChargeCode
+	}
+	if customerUsageInput.BillableMetricCode != "" {
+		queryParams["billable_metric_code"] = customerUsageInput.BillableMetricCode
+	}
+	for k, v := range customerUsageInput.Group {
+		queryParams[fmt.Sprintf("group[%s]", k)] = v
+	}
 	if customerUsageInput.FilterByChargeID != "" {
 		queryParams["filter_by_charge_id"] = customerUsageInput.FilterByChargeID
 	}

--- a/customer_test.go
+++ b/customer_test.go
@@ -939,7 +939,7 @@ func TestCustomerRequest_CurrentUsage(t *testing.T) {
 			ExternalSubscriptionID: "SUB_1",
 		})
 		c.Assert(result, qt.IsNil)
-		c.Assert(err.Error(), qt.Equals, `{"status":0,"error":"","code":"","err":"Get \"http://localhost:88888/api/v1/customers/CUSTOMER_1/current_usage?apply_taxes=false&external_subscription_id=SUB_1\": dial tcp: address 88888: invalid port"}`)
+		c.Assert(err.Error(), qt.Equals, "{\"status\":0,\"error\":\"\",\"code\":\"\",\"err\":\"Get \\\"http://localhost:88888/api/v1/customers/CUSTOMER_1/current_usage?apply_taxes=false\\u0026external_subscription_id=SUB_1\\\": dial tcp: address 88888: invalid port\"}")
 	})
 
 	filterTests := []struct {

--- a/customer_test.go
+++ b/customer_test.go
@@ -916,6 +916,98 @@ func TestCustomerCheckoutUrl(t *testing.T) {
 	})
 }
 
+var mockCustomerCurrentUsageResponse = map[string]any{
+	"customer_usage": map[string]any{
+		"from_datetime":      "2022-07-01T00:00:00Z",
+		"to_datetime":        "2022-07-31T23:59:59Z",
+		"issuing_date":       "2022-07-31",
+		"lago_invoice_id":    "1a901a90-1a90-1a90-1a90-1a901a901a90",
+		"currency":           "EUR",
+		"amount_cents":       123,
+		"total_amount_cents": 150,
+		"taxes_amount_cents": 27,
+		"charges_usage":      []map[string]any{},
+	},
+}
+
+func TestCustomerRequest_CurrentUsage(t *testing.T) {
+	t.Run("When the server is not reachable", func(t *testing.T) {
+		c := qt.New(t)
+
+		client := New().SetBaseURL("http://localhost:88888").SetApiKey("test_api_key")
+		result, err := client.Customer().CurrentUsage(context.Background(), "CUSTOMER_1", &CustomerUsageInput{
+			ExternalSubscriptionID: "SUB_1",
+		})
+		c.Assert(result, qt.IsNil)
+		c.Assert(err.Error(), qt.Equals, `{"status":0,"error":"","code":"","err":"Get \"http://localhost:88888/api/v1/customers/CUSTOMER_1/current_usage?apply_taxes=false&external_subscription_id=SUB_1\": dial tcp: address 88888: invalid port"}`)
+	})
+
+	filterTests := []struct {
+		name  string
+		input CustomerUsageInput
+		query string
+	}{
+		{
+			name:  "charge_id",
+			input: CustomerUsageInput{ChargeID: "charge_123"},
+			query: "external_subscription_id=SUB_1&apply_taxes=false&charge_id=charge_123",
+		},
+		{
+			name:  "charge_code",
+			input: CustomerUsageInput{ChargeCode: "my_charge"},
+			query: "external_subscription_id=SUB_1&apply_taxes=false&charge_code=my_charge",
+		},
+		{
+			name:  "billable_metric_code",
+			input: CustomerUsageInput{BillableMetricCode: "my_metric"},
+			query: "external_subscription_id=SUB_1&apply_taxes=false&billable_metric_code=my_metric",
+		},
+		{
+			name:  "group",
+			input: CustomerUsageInput{Group: map[string]string{"region": "us-east-1"}},
+			query: "external_subscription_id=SUB_1&apply_taxes=false&group[region]=us-east-1",
+		},
+		{
+			name:  "full_usage",
+			input: CustomerUsageInput{FullUsage: true},
+			query: "external_subscription_id=SUB_1&apply_taxes=false&full_usage=true",
+		},
+		{
+			name:  "filter_by_charge_id (deprecated)",
+			input: CustomerUsageInput{FilterByChargeID: "charge_123"},
+			query: "external_subscription_id=SUB_1&apply_taxes=false&filter_by_charge_id=charge_123",
+		},
+		{
+			name:  "filter_by_charge_code (deprecated)",
+			input: CustomerUsageInput{FilterByChargeCode: "my_charge"},
+			query: "external_subscription_id=SUB_1&apply_taxes=false&filter_by_charge_code=my_charge",
+		},
+		{
+			name:  "filter_by_group (deprecated)",
+			input: CustomerUsageInput{FilterByGroup: map[string]string{"region": "us-east-1"}},
+			query: "external_subscription_id=SUB_1&apply_taxes=false&filter_by_group[region]=us-east-1",
+		},
+	}
+
+	for _, tt := range filterTests {
+		t.Run("When using "+tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			tt.input.ExternalSubscriptionID = "SUB_1"
+			server := lt.NewMockServer(c).
+				MatchMethod("GET").
+				MatchPath("/api/v1/customers/CUSTOMER_1/current_usage").
+				MatchQuery(tt.query).
+				MockResponse(mockCustomerCurrentUsageResponse)
+			defer server.Close()
+
+			result, err := server.Client().Customer().CurrentUsage(context.Background(), "CUSTOMER_1", &tt.input)
+			c.Assert(err == nil, qt.IsTrue)
+			c.Assert(result.AmountCents, qt.Equals, 123)
+		})
+	}
+}
+
 func TestCustomerRequest_Get(t *testing.T) {
 	t.Run("When the server is not reachable", func(t *testing.T) {
 		c := qt.New(t)


### PR DESCRIPTION
## Context

We have different param naming convention in the `current_usage` endpoint. Some have the prefix `filter_by_`, not reflecting the pattern on the rest of the API. Add support for conventional ones, and mark the prefixed ones as deprecated.

## Description

Introduce unprefixed aliases for the `filter_by_*` query parameters on the `GET /customers/:customer_id/current_usage` endpoint (`charge_id, charge_code, billable_metric_code, group`), consistent with the naming convention used across the rest of the API.

The old `filter_by_*` names remain supported for backward compatibility.
