### PR TITLE
feat: expose rate limit headers via OnRateLimitInfo callback

### DIFF
--- a/lago.go
+++ b/lago.go
@@ -12,6 +12,9 @@ import (
 // executeWithRetry runs the given request function with automatic retry on HTTP 429 responses.
 // It respects the client's RetryPolicy settings including max attempts, backoff, and
 // the x-ratelimit-reset header from the server.
+//
+// On a non-429 response, if the RetryPolicy.OnRateLimitInfo callback is set,
+// the parsed x-ratelimit-* headers are delivered to it for observability.
 func (c *Client) executeWithRetry(ctx context.Context, fn func() (*resty.Response, error)) (*resty.Response, error) {
 	for attempt := 0; ; attempt++ {
 		resp, err := fn()
@@ -19,9 +22,14 @@ func (c *Client) executeWithRetry(ctx context.Context, fn func() (*resty.Respons
 			return resp, err
 		}
 
-		// If not rate limited, or retries disabled, or max attempts reached, return
-		if resp.StatusCode() != 429 ||
-			c.RetryPolicy == nil ||
+		// If not rate limited, emit observability info and return
+		if resp.StatusCode() != 429 {
+			c.emitRateLimitInfo(resp)
+			return resp, nil
+		}
+
+		// Rate limited but retries disabled or max attempts reached: return as-is
+		if c.RetryPolicy == nil ||
 			!c.RetryPolicy.EnableRetry ||
 			attempt >= c.RetryPolicy.MaxAttempts-1 {
 			return resp, nil
@@ -38,6 +46,23 @@ func (c *Client) executeWithRetry(ctx context.Context, fn func() (*resty.Respons
 			return resp, ctx.Err()
 		}
 	}
+}
+
+// emitRateLimitInfo invokes the configured OnRateLimitInfo callback (if any)
+// with parsed x-ratelimit-* headers from the given response.
+func (c *Client) emitRateLimitInfo(resp *resty.Response) {
+	if c.RetryPolicy == nil || c.RetryPolicy.OnRateLimitInfo == nil || resp == nil || resp.RawResponse == nil {
+		return
+	}
+	method := ""
+	url := ""
+	if resp.Request != nil && resp.Request.RawRequest != nil {
+		method = resp.Request.RawRequest.Method
+		if resp.Request.RawRequest.URL != nil {
+			url = resp.Request.RawRequest.URL.String()
+		}
+	}
+	c.RetryPolicy.emitRateLimitInfo(resp.RawResponse, method, url)
 }
 
 const baseURL string = "https://api.getlago.com"

--- a/observability.go
+++ b/observability.go
@@ -1,0 +1,72 @@
+package lago
+
+import (
+	"log"
+	"sort"
+	"strconv"
+)
+
+// DefaultRateLimitThresholds is the default set of usage thresholds at which
+// LoggingRateLimitObserver emits a warning.
+var DefaultRateLimitThresholds = []float64{0.80, 0.90, 0.95}
+
+// LoggingRateLimitObserver is a ready-to-use OnRateLimitInfo callback that
+// logs a warning each time rate limit usage crosses one of the configured
+// thresholds.
+//
+// Example:
+//
+//	client := lago.New().SetApiKey("...")
+//	client.RetryPolicy.OnRateLimitInfo = lago.NewLoggingRateLimitObserver(nil, nil)
+type LoggingRateLimitObserver struct {
+	thresholds []float64 // sorted descending
+	logger     *log.Logger
+}
+
+// NewLoggingRateLimitObserver returns a LoggingRateLimitObserver as a
+// RateLimitInfoCallback.
+//
+// Pass nil for thresholds to use DefaultRateLimitThresholds (80/90/95%).
+// Pass nil for logger to use the standard logger.
+func NewLoggingRateLimitObserver(thresholds []float64, logger *log.Logger) RateLimitInfoCallback {
+	if len(thresholds) == 0 {
+		thresholds = DefaultRateLimitThresholds
+	}
+	if logger == nil {
+		logger = log.Default()
+	}
+
+	sorted := make([]float64, len(thresholds))
+	copy(sorted, thresholds)
+	sort.Sort(sort.Reverse(sort.Float64Slice(sorted)))
+
+	o := &LoggingRateLimitObserver{thresholds: sorted, logger: logger}
+	return o.observe
+}
+
+func (o *LoggingRateLimitObserver) observe(info *RateLimitInfo) {
+	pct, ok := info.UsagePct()
+	if !ok {
+		return
+	}
+	for _, t := range o.thresholds {
+		if pct >= t {
+			o.logger.Printf(
+				"lago: rate limit at %.0f%% (limit=%s, remaining=%s, reset=%ss, %s %s)",
+				pct*100,
+				intPtrString(info.Limit),
+				intPtrString(info.Remaining),
+				intPtrString(info.Reset),
+				info.Method, info.URL,
+			)
+			return
+		}
+	}
+}
+
+func intPtrString(v *int) string {
+	if v == nil {
+		return "<nil>"
+	}
+	return strconv.Itoa(*v)
+}

--- a/rate_limit.go
+++ b/rate_limit.go
@@ -2,11 +2,45 @@ package lago
 
 import (
 	"context"
+	"log"
 	"math"
 	"net/http"
 	"strconv"
 	"time"
 )
+
+// RateLimitInfo holds parsed rate limit headers from a Lago API response.
+//
+// It is delivered to the OnRateLimitInfo callback after every successful
+// request so callers can build observability around the rate limit (warn at
+// thresholds, emit metrics, etc.).
+type RateLimitInfo struct {
+	// Limit is the parsed x-ratelimit-limit header (nil when absent or unparseable).
+	Limit *int
+	// Remaining is the parsed x-ratelimit-remaining header (nil when absent or unparseable).
+	Remaining *int
+	// Reset is the parsed x-ratelimit-reset header in seconds (nil when absent or unparseable).
+	Reset *int
+	// Method is the HTTP method of the call (GET, POST, ...).
+	Method string
+	// URL is the request URL.
+	URL string
+}
+
+// UsagePct returns the fraction of the rate limit currently used in [0.0, 1.0].
+//
+// It returns (0, false) when the headers aren't usable (missing limit, zero
+// limit, missing remaining).
+func (i *RateLimitInfo) UsagePct() (float64, bool) {
+	if i == nil || i.Limit == nil || i.Remaining == nil || *i.Limit <= 0 {
+		return 0, false
+	}
+	return 1.0 - float64(*i.Remaining)/float64(*i.Limit), true
+}
+
+// RateLimitInfoCallback is invoked after every successful response with parsed
+// rate limit headers.
+type RateLimitInfoCallback func(info *RateLimitInfo)
 
 // RetryPolicy defines the configuration for rate limit retry behavior.
 type RetryPolicy struct {
@@ -31,6 +65,12 @@ type RetryPolicy struct {
 	// Applies to both header-based and exponential backoff delays.
 	// Default is 20 seconds.
 	MaxRetryDelay int
+
+	// OnRateLimitInfo, when set, is invoked after every successful (non-429)
+	// response with parsed rate limit headers. Use it to build observability
+	// (warn at 80/90/95%, emit metrics, etc.). Panics from the callback are
+	// recovered and logged so a buggy observer cannot break the request flow.
+	OnRateLimitInfo RateLimitInfoCallback
 }
 
 // DefaultRetryPolicy returns a RetryPolicy with sensible defaults.
@@ -42,6 +82,61 @@ func DefaultRetryPolicy() *RetryPolicy {
 		BackoffMultiplier: 2.0,
 		MaxRetryDelay:     20,
 	}
+}
+
+// parseRateLimitInfo extracts x-ratelimit-* headers from a response into a
+// RateLimitInfo. Returns nil when no rate limit headers are present (for
+// example, on a self-hosted Lago instance that doesn't enforce limits).
+func parseRateLimitInfo(resp *http.Response, method, url string) *RateLimitInfo {
+	if resp == nil {
+		return nil
+	}
+
+	info := &RateLimitInfo{Method: method, URL: url}
+	hasAny := false
+
+	if v := resp.Header.Get("x-ratelimit-limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			info.Limit = intPtr(n)
+			hasAny = true
+		}
+	}
+	if v := resp.Header.Get("x-ratelimit-remaining"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			info.Remaining = intPtr(n)
+			hasAny = true
+		}
+	}
+	if v := resp.Header.Get("x-ratelimit-reset"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			info.Reset = intPtr(n)
+			hasAny = true
+		}
+	}
+
+	if !hasAny {
+		return nil
+	}
+	return info
+}
+
+// emitRateLimitInfo invokes the configured OnRateLimitInfo callback if any.
+// Panics from the callback are recovered and logged so the underlying request
+// flow is never affected.
+func (rp *RetryPolicy) emitRateLimitInfo(resp *http.Response, method, url string) {
+	if rp == nil || rp.OnRateLimitInfo == nil {
+		return
+	}
+	info := parseRateLimitInfo(resp, method, url)
+	if info == nil {
+		return
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("lago: OnRateLimitInfo callback panicked: %v", r)
+		}
+	}()
+	rp.OnRateLimitInfo(info)
 }
 
 // waitDuration calculates how long to wait before retrying.

--- a/rate_limit_test.go
+++ b/rate_limit_test.go
@@ -1,10 +1,13 @@
 package lago_test
 
 import (
+	"bytes"
 	"context"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -273,4 +276,204 @@ func TestSetRetryPolicy(t *testing.T) {
 	// Test disabling retries
 	client.SetRetryPolicy(nil)
 	c.Assert(client.RetryPolicy.EnableRetry, qt.IsFalse)
+}
+
+func TestRateLimitInfo_UsagePct(t *testing.T) {
+	c := qt.New(t)
+
+	// Full headers, 80% used
+	info := &RateLimitInfo{Limit: intPtr(100), Remaining: intPtr(20)}
+	pct, ok := info.UsagePct()
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(pct, qt.Equals, 0.80)
+
+	// Saturated
+	info = &RateLimitInfo{Limit: intPtr(100), Remaining: intPtr(0)}
+	pct, ok = info.UsagePct()
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(pct, qt.Equals, 1.0)
+
+	// Missing limit
+	info = &RateLimitInfo{Remaining: intPtr(20)}
+	_, ok = info.UsagePct()
+	c.Assert(ok, qt.IsFalse)
+
+	// Missing remaining
+	info = &RateLimitInfo{Limit: intPtr(100)}
+	_, ok = info.UsagePct()
+	c.Assert(ok, qt.IsFalse)
+
+	// Zero limit
+	info = &RateLimitInfo{Limit: intPtr(0), Remaining: intPtr(0)}
+	_, ok = info.UsagePct()
+	c.Assert(ok, qt.IsFalse)
+
+	// Nil receiver
+	var nilInfo *RateLimitInfo
+	_, ok = nilInfo.UsagePct()
+	c.Assert(ok, qt.IsFalse)
+}
+
+func TestOnRateLimitInfo_FiresOnSuccess(t *testing.T) {
+	c := qt.New(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("x-ratelimit-limit", "100")
+		w.Header().Set("x-ratelimit-remaining", "20")
+		w.Header().Set("x-ratelimit-reset", "5")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data": "success"}`))
+	}))
+	defer server.Close()
+
+	var (
+		mu       sync.Mutex
+		captured []*RateLimitInfo
+	)
+
+	client := New().SetBaseURL(server.URL).SetApiKey("k")
+	client.RetryPolicy.OnRateLimitInfo = func(info *RateLimitInfo) {
+		mu.Lock()
+		defer mu.Unlock()
+		captured = append(captured, info)
+	}
+
+	_, err := client.Get(context.Background(), &ClientRequest{Path: "test"})
+	c.Assert(err == nil, qt.IsTrue, qt.Commentf("err: %v", err))
+
+	mu.Lock()
+	defer mu.Unlock()
+	c.Assert(len(captured), qt.Equals, 1)
+	info := captured[0]
+	c.Assert(info.Limit, qt.Not(qt.IsNil))
+	c.Assert(*info.Limit, qt.Equals, 100)
+	c.Assert(*info.Remaining, qt.Equals, 20)
+	c.Assert(*info.Reset, qt.Equals, 5)
+	pct, ok := info.UsagePct()
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(pct, qt.Equals, 0.80)
+	c.Assert(info.Method, qt.Equals, "GET")
+}
+
+func TestOnRateLimitInfo_NotCalledWhenHeadersAbsent(t *testing.T) {
+	c := qt.New(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data": "success"}`))
+	}))
+	defer server.Close()
+
+	called := 0
+	client := New().SetBaseURL(server.URL).SetApiKey("k")
+	client.RetryPolicy.OnRateLimitInfo = func(info *RateLimitInfo) {
+		called++
+	}
+
+	_, err := client.Get(context.Background(), &ClientRequest{Path: "test"})
+	c.Assert(err == nil, qt.IsTrue, qt.Commentf("err: %v", err))
+	c.Assert(called, qt.Equals, 0)
+}
+
+func TestOnRateLimitInfo_PanicIsRecovered(t *testing.T) {
+	c := qt.New(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("x-ratelimit-limit", "100")
+		w.Header().Set("x-ratelimit-remaining", "1")
+		w.Header().Set("x-ratelimit-reset", "5")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data": "success"}`))
+	}))
+	defer server.Close()
+
+	client := New().SetBaseURL(server.URL).SetApiKey("k")
+	client.RetryPolicy.OnRateLimitInfo = func(info *RateLimitInfo) {
+		panic("intentional")
+	}
+
+	_, err := client.Get(context.Background(), &ClientRequest{Path: "test"})
+	c.Assert(err == nil, qt.IsTrue, qt.Commentf("err: %v", err))
+}
+
+func TestOnRateLimitInfo_FiresOnceAfter429RetrySucceeds(t *testing.T) {
+	c := qt.New(t)
+	requests := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.Header().Set("Content-Type", "application/json")
+		if requests == 1 {
+			w.Header().Set("x-ratelimit-reset", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"status":429,"error":"Too Many Requests"}`))
+			return
+		}
+		w.Header().Set("x-ratelimit-limit", "100")
+		w.Header().Set("x-ratelimit-remaining", "50")
+		w.Header().Set("x-ratelimit-reset", "5")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":"ok"}`))
+	}))
+	defer server.Close()
+
+	var captured []*RateLimitInfo
+	client := New().SetBaseURL(server.URL).SetApiKey("k")
+	client.RetryPolicy.OnRateLimitInfo = func(info *RateLimitInfo) {
+		captured = append(captured, info)
+	}
+
+	_, err := client.Get(context.Background(), &ClientRequest{Path: "test"})
+	c.Assert(err == nil, qt.IsTrue, qt.Commentf("err: %v", err))
+	c.Assert(requests, qt.Equals, 2)
+	c.Assert(len(captured), qt.Equals, 1)
+	c.Assert(*captured[0].Remaining, qt.Equals, 50)
+}
+
+func TestLoggingRateLimitObserver_LogsAboveThreshold(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	logger := log.New(&buf, "", 0)
+
+	observer := NewLoggingRateLimitObserver([]float64{0.80, 0.90, 0.95}, logger)
+	observer(&RateLimitInfo{
+		Limit:     intPtr(100),
+		Remaining: intPtr(4), // 96% used
+		Reset:     intPtr(10),
+		Method:    "GET",
+		URL:       "https://x",
+	})
+
+	out := buf.String()
+	c.Assert(strings.Contains(out, "96%"), qt.IsTrue, qt.Commentf("logger output: %q", out))
+}
+
+func TestLoggingRateLimitObserver_SilentBelowThreshold(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	logger := log.New(&buf, "", 0)
+
+	observer := NewLoggingRateLimitObserver([]float64{0.80}, logger)
+	observer(&RateLimitInfo{
+		Limit:     intPtr(100),
+		Remaining: intPtr(50), // 50% used
+	})
+
+	c.Assert(buf.Len(), qt.Equals, 0)
+}
+
+func TestLoggingRateLimitObserver_DefaultThresholds(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	logger := log.New(&buf, "", 0)
+
+	observer := NewLoggingRateLimitObserver(nil, logger)
+	observer(&RateLimitInfo{Limit: intPtr(100), Remaining: intPtr(15)}) // 85%
+	c.Assert(strings.Contains(buf.String(), "85%"), qt.IsTrue)
 }


### PR DESCRIPTION
Adds an optional `OnRateLimitInfo` callback on `RetryPolicy` so callers can read `x-ratelimit-*` headers from successful responses. Today the SDK drops them on 2xx, which makes 80/90/95% threshold observability impossible without poking at internals. The 429 path (via `RateLimitError`) is unchanged. Mirrors PR getlago/lago-python-client#393.

### Notes for review

- New field is optional (zero-value `nil`) so default behavior is unchanged.
- Callback fires only on successful responses with rate limit headers present.
- Callback panics are recovered and logged so a buggy observer can't break a request.
- Sync, runs inline before returning to the caller.

### Tests

8 new tests in `rate_limit_test.go`. Full suite passes.