### PR TITLE
fix: wrap WebhookEndpoint Update body under webhook_endpoint key

### DIFF
--- a/webhook_endpoint.go
+++ b/webhook_endpoint.go
@@ -130,10 +130,14 @@ func (wer *WebhookEndpointRequest) Create(ctx context.Context, webhookEndpointIn
 
 func (wer *WebhookEndpointRequest) Update(ctx context.Context, webhookEndpointInput *WebhookEndpointInput, webhookEndpointID string) (*WebhookEndpoint, *Error) {
 	subPath := fmt.Sprintf("%s/%s", "webhook_endpoints", webhookEndpointID)
+	webhookEndpointParams := &WebhookEndpointParams{
+		WebhookEndpointInput: webhookEndpointInput,
+	}
+
 	clientRequest := &ClientRequest{
 		Path:   subPath,
 		Result: &WebhookEndpointResult{},
-		Body:   webhookEndpointInput,
+		Body:   webhookEndpointParams,
 	}
 
 	result, err := wer.client.Put(ctx, clientRequest)

--- a/webhook_endpoint_test.go
+++ b/webhook_endpoint_test.go
@@ -1,0 +1,60 @@
+package lago_test
+
+import (
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	. "github.com/getlago/lago-go-client"
+	lt "github.com/getlago/lago-go-client/testing"
+)
+
+var mockWebhookEndpointResponse = map[string]any{
+	"webhook_endpoint": map[string]any{
+		"lago_id":              "1a901a90-1a90-1a90-1a90-1a901a901a90",
+		"lago_organization_id": "2b902b90-2b90-2b90-2b90-2b902b902b90",
+		"webhook_url":          "https://example.com/webhook",
+		"signature_algo":       "jwt",
+		"created_at":           "2025-01-01T10:00:00Z",
+	},
+}
+
+func TestWebhookEndpointRequest_Create(t *testing.T) {
+	t.Run("Wraps the body under the webhook_endpoint key", func(t *testing.T) {
+		c := qt.New(t)
+
+		server := lt.NewMockServer(c).
+			MatchMethod("POST").
+			MatchPath("/api/v1/webhook_endpoints").
+			MatchJSONBody(`{"webhook_endpoint":{"webhook_url":"https://example.com/webhook","signature_algo":"jwt"}}`).
+			MockResponse(mockWebhookEndpointResponse)
+		defer server.Close()
+
+		result, err := server.Client().WebhookEndpoint().Create(context.Background(), &WebhookEndpointInput{
+			WebhookURL:    "https://example.com/webhook",
+			SignatureAlgo: JWT,
+		})
+		c.Assert(err == nil, qt.IsTrue)
+		c.Assert(result.WebhookURL, qt.Equals, "https://example.com/webhook")
+	})
+}
+
+func TestWebhookEndpointRequest_Update(t *testing.T) {
+	t.Run("Wraps the body under the webhook_endpoint key", func(t *testing.T) {
+		c := qt.New(t)
+
+		server := lt.NewMockServer(c).
+			MatchMethod("PUT").
+			MatchPath("/api/v1/webhook_endpoints/1a901a90-1a90-1a90-1a90-1a901a901a90").
+			MatchJSONBody(`{"webhook_endpoint":{"webhook_url":"https://example.com/webhook","signature_algo":"jwt"}}`).
+			MockResponse(mockWebhookEndpointResponse)
+		defer server.Close()
+
+		result, err := server.Client().WebhookEndpoint().Update(context.Background(), &WebhookEndpointInput{
+			WebhookURL:    "https://example.com/webhook",
+			SignatureAlgo: JWT,
+		}, "1a901a90-1a90-1a90-1a90-1a901a901a90")
+		c.Assert(err == nil, qt.IsTrue)
+		c.Assert(result.WebhookURL, qt.Equals, "https://example.com/webhook")
+	})
+}


### PR DESCRIPTION
## Summary

- Wraps the body of `WebhookEndpointRequest.Update` in `WebhookEndpointParams` so the PUT payload is sent as `{"webhook_endpoint": {...}}`, matching `Create` and what the Lago API requires.
- Adds tests asserting the JSON body shape for both `Create` and `Update` (catching this regression class in CI).

Fixes #339.

## Bug

`WebhookEndpoint().Update(...)` currently sends the raw input unwrapped, so the Lago API rejects it with:

```
{"status":400,"error":"BadRequest: param is missing or the value is empty or invalid: webhook_endpoint"}
```

`Create` already wraps the body correctly via `WebhookEndpointParams` (which has the `json:"webhook_endpoint"` tag) — `Update` just needs the same treatment.

## Diff

```diff
 func (wer *WebhookEndpointRequest) Update(ctx context.Context, webhookEndpointInput *WebhookEndpointInput, webhookEndpointID string) (*WebhookEndpoint, *Error) {
     subPath := fmt.Sprintf("%s/%s", "webhook_endpoints", webhookEndpointID)
+    webhookEndpointParams := &WebhookEndpointParams{
+        WebhookEndpointInput: webhookEndpointInput,
+    }
+
     clientRequest := &ClientRequest{
         Path:   subPath,
         Result: &WebhookEndpointResult{},
-        Body:   webhookEndpointInput,
+        Body:   webhookEndpointParams,
     }
```

## Audit

I checked every other `Update` / PUT / PATCH method in the SDK for the same Create-wraps / Update-doesn't pattern. `WebhookEndpoint().Update` is the only one affected — every other resource (`add_on`, `coupon`, `customer`, `plan`, `tax`, `billable_metric`, `organization`, `subscription`, etc.) already wraps the Update body consistently with Create.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all existing tests pass, plus two new tests in `webhook_endpoint_test.go` covering Create and Update body wrapping)