### PR TITLE
[ING-30] feat: Add currency filter to list inputs

### DIFF
--- a/payment_request.go
+++ b/payment_request.go
@@ -25,6 +25,7 @@ type PaymentRequestListInput struct {
 
 	ExternalCustomerID string `json:"external_customer_id,omitempty"`
 	PaymentStatus      string `json:"payment_status,omitempty"`
+	Currency           string `json:"currency,omitempty"`
 }
 
 type PaymentRequest struct {

--- a/subscription.go
+++ b/subscription.go
@@ -118,6 +118,7 @@ type SubscriptionTerminateInput struct {
 type SubscriptionListInput struct {
 	ExternalCustomerID string               `url:"external_customer_id,omitempty"`
 	PlanCode           string               `url:"plan_code,omitempty"`
+	Currency           string               `url:"currency,omitempty"`
 	PerPage            *int                 `url:"per_page,omitempty"`
 	Page               *int                 `url:"page,omitempty"`
 	Status             []SubscriptionStatus `url:"status[],omitempty"`

--- a/wallet.go
+++ b/wallet.go
@@ -96,6 +96,7 @@ type WalletListInput struct {
 	PerPage            *int   `json:"per_page,omitempty,string"`
 	Page               *int   `json:"page,omitempty,string"`
 	ExternalCustomerID string `json:"external_customer_id,omitempty"`
+	Currency           string `json:"currency,omitempty"`
 }
 
 type WalletResult struct {


### PR DESCRIPTION
## Context

The lago-api backend exposes an optional `currency` query parameter on the subscriptions, wallets, and payment_requests list endpoints (getlago/lago-api#5249). The Go client list inputs did not surface it, so users could not filter these lists by currency through the typed API.

## Description

Adds a `Currency` field to `SubscriptionListInput`, `WalletListInput`, and `PaymentRequestListInput`. The struct tag matches each list method's serializer: `SubscriptionRequest.GetList` encodes via `query.Values` (go-querystring, which reads `url:` tags), while `WalletRequest.GetList` and `PaymentRequestRequest.GetList` encode via `json.Marshal` into a `map[string]string` (which reads `json:` tags). `omitempty` keeps the parameter out of the query string when unset.

## How to try locally

```
go build ./...
go test ./...
```

Then pass `Currency: "EUR"` in any of the three list inputs.