### PR TITLE
fix(BIL-17): Handle empty retry payment responses

### DIFF
--- a/invoice.go
+++ b/invoice.go
@@ -537,8 +537,7 @@ func (ir *InvoiceRequest) LoseDispute(ctx context.Context, invoiceID string) (*I
 func (ir *InvoiceRequest) RetryPayment(ctx context.Context, invoiceID string, paymentMethod ...*PaymentMethodInput) (*Invoice, *Error) {
 	subPath := fmt.Sprintf("%s/%s/%s", "invoices", invoiceID, "retry_payment")
 	clientRequest := &ClientRequest{
-		Path:   subPath,
-		Result: &InvoiceResult{},
+		Path: subPath,
 	}
 
 	// We don't return an invoice here due to async retry payment processing
@@ -546,15 +545,10 @@ func (ir *InvoiceRequest) RetryPayment(ctx context.Context, invoiceID string, pa
 		clientRequest.Body = &RetryPaymentParams{
 			PaymentMethod: paymentMethod[0],
 		}
-		_, err := ir.client.Post(ctx, clientRequest)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		_, err := ir.client.PostWithoutBody(ctx, clientRequest)
-		if err != nil {
-			return nil, err
-		}
+	}
+
+	if err := ir.client.PostWithoutResult(ctx, clientRequest); err != nil {
+		return nil, err
 	}
 
 	return nil, nil

--- a/invoice_test.go
+++ b/invoice_test.go
@@ -347,7 +347,7 @@ func TestInvoiceRequest_RetryPayment(t *testing.T) {
 		server := lt.NewMockServer(c).
 			MatchMethod("POST").
 			MatchPath("/api/v1/invoices/1a901a90-1a90-1a90-1a90-1a901a901a90/retry_payment").
-			MockResponse(map[string]any{})
+			MockResponse(nil)
 		defer server.Close()
 
 		_, err := server.Client().Invoice().RetryPayment(context.Background(), "1a901a90-1a90-1a90-1a90-1a901a901a90")
@@ -366,7 +366,7 @@ func TestInvoiceRequest_RetryPayment(t *testing.T) {
 					"payment_method_id": "pm_123456"
 				}
 			}`).
-			MockResponse(map[string]any{})
+			MockResponse(nil)
 		defer server.Close()
 
 		_, err := server.Client().Invoice().RetryPayment(context.Background(), "1a901a90-1a90-1a90-1a90-1a901a901a90", &PaymentMethodInput{

--- a/lago.go
+++ b/lago.go
@@ -302,11 +302,15 @@ func (c *Client) Post(ctx context.Context, cr *ClientRequest) (interface{}, *Err
 
 func (c *Client) PostWithoutResult(ctx context.Context, cr *ClientRequest) *Error {
 	resp, retryErr := c.executeWithRetry(ctx, func() (*resty.Response, error) {
-		return c.HttpClient.R().
+		request := c.HttpClient.R().
 			SetContext(ctx).
-			SetError(&Error{}).
-			SetBody(cr.Body).
-			Post(cr.Path)
+			SetError(&Error{})
+
+		if cr.Body != nil {
+			request.SetBody(cr.Body)
+		}
+
+		return request.Post(cr.Path)
 	})
 	if retryErr != nil {
 		return &Error{Err: retryErr}


### PR DESCRIPTION
## Summary
- Fixes BIL-17 / https://linear.app/getlago/issue/BIL-17/retryinvoicepayment-api-returns-json-parse-error
- Stop decoding `RetryPayment` responses into an invoice result because the endpoint only enqueues async retry processing and can return an empty successful body.
- Allow no-result POST requests to omit the body when no body is needed.
- Cover retry payment calls with empty successful responses, with and without a payment method.

## Verification
- `gofmt -w lago.go invoice.go invoice_test.go`
- `env GOCACHE=/private/tmp/go-build GOPATH=/private/tmp/go go test ./...`