### PR TITLE
feat(presentation_group_keys): Support presentation breakdowns feature

### DIFF
--- a/charge.go
+++ b/charge.go
@@ -23,6 +23,15 @@ type AppliedPricingUnit struct {
 	ConversionRate float64 `json:"conversion_rate,omitempty"`
 }
 
+type ChargePresentationGroupKeyOptions struct {
+	DisplayInInvoice bool `json:"display_in_invoice,omitempty"`
+}
+
+type ChargePresentationGroupKey struct {
+	Value   string                            `json:"value,omitempty"`
+	Options ChargePresentationGroupKeyOptions `json:"options,omitempty"`
+}
+
 type ChargeFilter struct {
 	InvoiceDisplayName string                 `json:"invoice_display_name,omitempty"`
 	Properties         map[string]interface{} `json:"properties,omitempty"`

--- a/customer.go
+++ b/customer.go
@@ -215,31 +215,39 @@ type IntegrationCustomersResponse struct {
 	SyncWithProvider   bool            `json:"sync_with_provider,omitempty"`
 }
 
+type PresentationBreakdown struct {
+	PresentationBy map[string]string `json:"presentation_by,omitempty"`
+	Units          string            `json:"units,omitempty"`
+}
+
 type CustomerChargeUsage struct {
-	TotalAggregatedUnits string                       `json:"total_aggregated_units,omitempty"`
-	Units                string                       `json:"units,omitempty"`
-	EventsCount          int                          `json:"events_count"`
-	AmountCents          int                          `json:"amount_cents,omitempty"`
-	AmountCurrency       Currency                     `json:"amount_currency,omitempty"`
-	Charge               *Charge                      `json:"charge,omitempty"`
-	BillableMetric       *BillableMetric              `json:"billable_metric,omitempty"`
-	PricingUnitDetails   *CustomerPricingUnitDetails  `json:"pricing_unit_details,omitempty"`
-	Filters              []CustomerChargeFilterUsage  `json:"filters,omitempty"`
-	GroupedUsage         []CustomerChargeGroupedUsage `json:"grouped_usage,omitempty"`
+	TotalAggregatedUnits   string                       `json:"total_aggregated_units,omitempty"`
+	Units                  string                       `json:"units,omitempty"`
+	EventsCount            int                          `json:"events_count"`
+	AmountCents            int                          `json:"amount_cents,omitempty"`
+	AmountCurrency         Currency                     `json:"amount_currency,omitempty"`
+	Charge                 *Charge                      `json:"charge,omitempty"`
+	BillableMetric         *BillableMetric              `json:"billable_metric,omitempty"`
+	PricingUnitDetails     *CustomerPricingUnitDetails  `json:"pricing_unit_details,omitempty"`
+	Filters                []CustomerChargeFilterUsage  `json:"filters,omitempty"`
+	GroupedUsage           []CustomerChargeGroupedUsage `json:"grouped_usage,omitempty"`
+	PresentationBreakdowns []PresentationBreakdown      `json:"presentation_breakdowns,omitempty"`
 }
 
 type CustomerProjectedChargeUsage struct {
-	Units                string                                `json:"units,omitempty"`
-	ProjectedUnits       string                                `json:"projected_units,omitempty"`
-	EventsCount          int                                   `json:"events_count"`
-	AmountCents          int                                   `json:"amount_cents,omitempty"`
-	ProjectedAmountCents int                                   `json:"projected_amount_cents,omitempty"`
-	AmountCurrency       Currency                              `json:"amount_currency,omitempty"`
-	Charge               *Charge                               `json:"charge,omitempty"`
-	BillableMetric       *BillableMetric                       `json:"billable_metric,omitempty"`
-	PricingUnitDetails   *CustomerPricingUnitDetails           `json:"pricing_unit_details,omitempty"`
-	Filters              []CustomerProjectedChargeFilterUsage  `json:"filters,omitempty"`
-	GroupedUsage         []CustomerProjectedChargeGroupedUsage `json:"grouped_usage,omitempty"`
+	Units                           string                                `json:"units,omitempty"`
+	ProjectedUnits                  string                                `json:"projected_units,omitempty"`
+	EventsCount                     int                                   `json:"events_count"`
+	AmountCents                     int                                   `json:"amount_cents,omitempty"`
+	ProjectedAmountCents            int                                   `json:"projected_amount_cents,omitempty"`
+	AmountCurrency                  Currency                              `json:"amount_currency,omitempty"`
+	Charge                          *Charge                               `json:"charge,omitempty"`
+	BillableMetric                  *BillableMetric                       `json:"billable_metric,omitempty"`
+	PricingUnitDetails              *CustomerPricingUnitDetails           `json:"pricing_unit_details,omitempty"`
+	Filters                         []CustomerProjectedChargeFilterUsage  `json:"filters,omitempty"`
+	GroupedUsage                    []CustomerProjectedChargeGroupedUsage `json:"grouped_usage,omitempty"`
+	PresentationBreakdowns          []PresentationBreakdown               `json:"presentation_breakdowns,omitempty"`
+	ProjectedPresentationBreakdowns []PresentationBreakdown               `json:"projected_presentation_breakdowns,omitempty"`
 }
 
 type CustomerPricingUnitDetails struct {
@@ -249,45 +257,51 @@ type CustomerPricingUnitDetails struct {
 }
 
 type CustomerChargeFilterUsage struct {
-	TotalAggregatedUnits string                      `json:"total_aggregated_units,omitempty"`
-	InvoiceDisplayName   string                      `json:"invoice_display_name,omitempty"`
-	Values               map[string]interface{}      `json:"value,omitempty"`
-	AmountCents          int                         `json:"amount_cents,omitempty"`
-	EventsCount          int                         `json:"events_count,omitempty"`
-	Units                string                      `json:"units,omitempty"`
-	PricingUnitDetails   *CustomerPricingUnitDetails `json:"pricing_unit_details,omitempty"`
+	TotalAggregatedUnits   string                      `json:"total_aggregated_units,omitempty"`
+	InvoiceDisplayName     string                      `json:"invoice_display_name,omitempty"`
+	Values                 map[string]interface{}      `json:"value,omitempty"`
+	AmountCents            int                         `json:"amount_cents,omitempty"`
+	EventsCount            int                         `json:"events_count,omitempty"`
+	Units                  string                      `json:"units,omitempty"`
+	PricingUnitDetails     *CustomerPricingUnitDetails `json:"pricing_unit_details,omitempty"`
+	PresentationBreakdowns []PresentationBreakdown     `json:"presentation_breakdowns,omitempty"`
 }
 
 type CustomerProjectedChargeFilterUsage struct {
-	InvoiceDisplayName   string                      `json:"invoice_display_name,omitempty"`
-	Values               map[string]interface{}      `json:"value,omitempty"`
-	AmountCents          int                         `json:"amount_cents,omitempty"`
-	ProjectedAmountCents int                         `json:"projected_amount_cents,omitempty"`
-	EventsCount          int                         `json:"events_count,omitempty"`
-	Units                string                      `json:"units,omitempty"`
-	ProjectedUnits       string                      `json:"projected_units,omitempty"`
-	PricingUnitDetails   *CustomerPricingUnitDetails `json:"pricing_unit_details,omitempty"`
+	InvoiceDisplayName              string                      `json:"invoice_display_name,omitempty"`
+	Values                          map[string]interface{}      `json:"value,omitempty"`
+	AmountCents                     int                         `json:"amount_cents,omitempty"`
+	ProjectedAmountCents            int                         `json:"projected_amount_cents,omitempty"`
+	EventsCount                     int                         `json:"events_count,omitempty"`
+	Units                           string                      `json:"units,omitempty"`
+	ProjectedUnits                  string                      `json:"projected_units,omitempty"`
+	PricingUnitDetails              *CustomerPricingUnitDetails `json:"pricing_unit_details,omitempty"`
+	PresentationBreakdowns          []PresentationBreakdown     `json:"presentation_breakdowns,omitempty"`
+	ProjectedPresentationBreakdowns []PresentationBreakdown     `json:"projected_presentation_breakdowns,omitempty"`
 }
 
 type CustomerChargeGroupedUsage struct {
-	TotalAggregatedUnits string                      `json:"total_aggregated_units,omitempty"`
-	AmountCents          int                         `json:"amount_cents,omitempty"`
-	EventsCount          int                         `json:"events_count,omitempty"`
-	Units                string                      `json:"units,omitempty"`
-	GroupedBy            map[string]interface{}      `json:"grouped_by,omitempty"`
-	Filters              []CustomerChargeFilterUsage `json:"filters,omitempty"`
-	PricingUnitDetails   *CustomerPricingUnitDetails `json:"pricing_unit_details,omitempty"`
+	TotalAggregatedUnits   string                      `json:"total_aggregated_units,omitempty"`
+	AmountCents            int                         `json:"amount_cents,omitempty"`
+	EventsCount            int                         `json:"events_count,omitempty"`
+	Units                  string                      `json:"units,omitempty"`
+	GroupedBy              map[string]interface{}      `json:"grouped_by,omitempty"`
+	Filters                []CustomerChargeFilterUsage `json:"filters,omitempty"`
+	PricingUnitDetails     *CustomerPricingUnitDetails `json:"pricing_unit_details,omitempty"`
+	PresentationBreakdowns []PresentationBreakdown     `json:"presentation_breakdowns,omitempty"`
 }
 
 type CustomerProjectedChargeGroupedUsage struct {
-	AmountCents          int                         `json:"amount_cents,omitempty"`
-	ProjectedAmountCents int                         `json:"projected_amount_cents,omitempty"`
-	EventsCount          int                         `json:"events_count,omitempty"`
-	Units                string                      `json:"units,omitempty"`
-	ProjectedUnits       string                      `json:"projected_units,omitempty"`
-	GroupedBy            map[string]interface{}      `json:"grouped_by,omitempty"`
-	Filters              []CustomerChargeFilterUsage `json:"filters,omitempty"`
-	PricingUnitDetails   *CustomerPricingUnitDetails `json:"pricing_unit_details,omitempty"`
+	AmountCents                     int                                  `json:"amount_cents,omitempty"`
+	ProjectedAmountCents            int                                  `json:"projected_amount_cents,omitempty"`
+	EventsCount                     int                                  `json:"events_count,omitempty"`
+	Units                           string                               `json:"units,omitempty"`
+	ProjectedUnits                  string                               `json:"projected_units,omitempty"`
+	GroupedBy                       map[string]interface{}               `json:"grouped_by,omitempty"`
+	Filters                         []CustomerProjectedChargeFilterUsage `json:"filters,omitempty"`
+	PricingUnitDetails              *CustomerPricingUnitDetails          `json:"pricing_unit_details,omitempty"`
+	PresentationBreakdowns          []PresentationBreakdown              `json:"presentation_breakdowns,omitempty"`
+	ProjectedPresentationBreakdowns []PresentationBreakdown              `json:"projected_presentation_breakdowns,omitempty"`
 }
 
 type CustomerUsage struct {
@@ -335,6 +349,7 @@ type CustomerUsageInput struct {
 	BillableMetricCode     string            `json:"billable_metric_code,omitempty"`
 	Group                  map[string]string `json:"group,omitempty"`
 	FullUsage              bool              `json:"full_usage,omitempty"`
+	FilterByPresentation   []string          `json:"filter_by_presentation,omitempty"`
 
 	// Deprecated: Use ChargeID instead.
 	FilterByChargeID string `json:"filter_by_charge_id,omitempty"`
@@ -517,40 +532,46 @@ func (cr *CustomerRequest) Update(ctx context.Context, customerInput *CustomerIn
 func (cr *CustomerRequest) CurrentUsage(ctx context.Context, externalCustomerID string, customerUsageInput *CustomerUsageInput) (*CustomerUsage, *Error) {
 	subPath := fmt.Sprintf("%s/%s/%s", "customers", externalCustomerID, "current_usage")
 
-	queryParams := map[string]string{
-		"external_subscription_id": customerUsageInput.ExternalSubscriptionID,
-		"apply_taxes":              strconv.FormatBool(customerUsageInput.ApplyTaxes),
-	}
+	urlValues := url.Values{}
+	urlValues.Set("external_subscription_id", customerUsageInput.ExternalSubscriptionID)
+	urlValues.Set("apply_taxes", strconv.FormatBool(customerUsageInput.ApplyTaxes))
 
 	if customerUsageInput.ChargeID != "" {
-		queryParams["charge_id"] = customerUsageInput.ChargeID
+		urlValues.Set("charge_id", customerUsageInput.ChargeID)
 	}
 	if customerUsageInput.ChargeCode != "" {
-		queryParams["charge_code"] = customerUsageInput.ChargeCode
+		urlValues.Set("charge_code", customerUsageInput.ChargeCode)
 	}
 	if customerUsageInput.BillableMetricCode != "" {
-		queryParams["billable_metric_code"] = customerUsageInput.BillableMetricCode
+		urlValues.Set("billable_metric_code", customerUsageInput.BillableMetricCode)
 	}
 	for k, v := range customerUsageInput.Group {
-		queryParams[fmt.Sprintf("group[%s]", k)] = v
+		urlValues.Set(fmt.Sprintf("group[%s]", k), v)
 	}
 	if customerUsageInput.FilterByChargeID != "" {
-		queryParams["filter_by_charge_id"] = customerUsageInput.FilterByChargeID
+		urlValues.Set("filter_by_charge_id", customerUsageInput.FilterByChargeID)
 	}
 	if customerUsageInput.FilterByChargeCode != "" {
-		queryParams["filter_by_charge_code"] = customerUsageInput.FilterByChargeCode
+		urlValues.Set("filter_by_charge_code", customerUsageInput.FilterByChargeCode)
 	}
 	for k, v := range customerUsageInput.FilterByGroup {
-		queryParams[fmt.Sprintf("filter_by_group[%s]", k)] = v
+		urlValues.Set(fmt.Sprintf("filter_by_group[%s]", k), v)
 	}
 	if customerUsageInput.FullUsage {
-		queryParams["full_usage"] = "true"
+		urlValues.Set("full_usage", "true")
+	}
+	if customerUsageInput.FilterByPresentation != nil {
+		filterByPresentation, err := json.Marshal(customerUsageInput.FilterByPresentation)
+		if err != nil {
+			return nil, &Error{Err: err}
+		}
+		urlValues.Set("filter_by_presentation", string(filterByPresentation))
 	}
 
 	clientRequest := &ClientRequest{
-		Path:        subPath,
-		QueryParams: queryParams,
-		Result:      &CustomerUsageResult{},
+		Path:      subPath,
+		UrlValues: urlValues,
+		Result:    &CustomerUsageResult{},
 	}
 
 	result, clientErr := cr.client.Get(ctx, clientRequest)

--- a/customer_test.go
+++ b/customer_test.go
@@ -2,6 +2,7 @@ package lago_test
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -973,6 +974,16 @@ func TestCustomerRequest_CurrentUsage(t *testing.T) {
 			query: "external_subscription_id=SUB_1&apply_taxes=false&full_usage=true",
 		},
 		{
+			name:  "filter_by_presentation",
+			input: CustomerUsageInput{FilterByPresentation: []string{"engineering", "operations"}},
+			query: `external_subscription_id=SUB_1&apply_taxes=false&filter_by_presentation=["engineering","operations"]`,
+		},
+		{
+			name:  "empty filter_by_presentation",
+			input: CustomerUsageInput{FilterByPresentation: []string{}},
+			query: `external_subscription_id=SUB_1&apply_taxes=false&filter_by_presentation=[]`,
+		},
+		{
 			name:  "filter_by_charge_id (deprecated)",
 			input: CustomerUsageInput{FilterByChargeID: "charge_123"},
 			query: "external_subscription_id=SUB_1&apply_taxes=false&filter_by_charge_id=charge_123",
@@ -1006,6 +1017,128 @@ func TestCustomerRequest_CurrentUsage(t *testing.T) {
 			c.Assert(result.AmountCents, qt.Equals, 123)
 		})
 	}
+
+	t.Run("When receiving presentation breakdowns", func(t *testing.T) {
+		c := qt.New(t)
+
+		response := map[string]any{
+			"customer_usage": map[string]any{
+				"charges_usage": []map[string]any{
+					{
+						"presentation_breakdowns": []map[string]any{
+							{"presentation_by": map[string]any{"team": "engineering"}, "units": "9.0"},
+						},
+						"filters": []map[string]any{
+							{
+								"presentation_breakdowns": []map[string]any{
+									{"presentation_by": map[string]any{"team": "operations"}, "units": "3.0"},
+								},
+							},
+						},
+						"grouped_usage": []map[string]any{
+							{
+								"presentation_breakdowns": []map[string]any{
+									{"presentation_by": map[string]any{"region": "eu"}, "units": "5.0"},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		server := lt.NewMockServer(c).
+			MatchMethod("GET").
+			MatchPath("/api/v1/customers/CUSTOMER_1/current_usage").
+			MatchQuery("external_subscription_id=SUB_1&apply_taxes=false").
+			MockResponse(response)
+		defer server.Close()
+
+		result, err := server.Client().Customer().CurrentUsage(context.Background(), "CUSTOMER_1", &CustomerUsageInput{
+			ExternalSubscriptionID: "SUB_1",
+		})
+		c.Assert(err == nil, qt.IsTrue)
+		c.Assert(result.ChargesUsage[0].PresentationBreakdowns[0].PresentationBy["team"], qt.Equals, "engineering")
+		c.Assert(result.ChargesUsage[0].Filters[0].PresentationBreakdowns[0].Units, qt.Equals, "3.0")
+		c.Assert(result.ChargesUsage[0].GroupedUsage[0].PresentationBreakdowns[0].PresentationBy["region"], qt.Equals, "eu")
+	})
+
+	t.Run("When receiving projected presentation breakdowns", func(t *testing.T) {
+		c := qt.New(t)
+
+		response := map[string]any{
+			"customer_projected_usage": map[string]any{
+				"charges_usage": []map[string]any{
+					{
+						"presentation_breakdowns": []map[string]any{
+							{"presentation_by": map[string]any{"team": "engineering"}, "units": "9.0"},
+						},
+						"projected_presentation_breakdowns": []map[string]any{
+							{"presentation_by": map[string]any{"team": "engineering"}, "units": "18.0"},
+						},
+						"filters": []map[string]any{
+							{
+								"projected_units": "2.0",
+								"projected_presentation_breakdowns": []map[string]any{
+									{"presentation_by": map[string]any{"team": "operations"}, "units": "6.0"},
+								},
+							},
+						},
+						"grouped_usage": []map[string]any{
+							{
+								"filters": []map[string]any{
+									{"projected_units": "4.0"},
+								},
+								"projected_presentation_breakdowns": []map[string]any{
+									{"presentation_by": map[string]any{"region": "eu"}, "units": "10.0"},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		server := lt.NewMockServer(c).
+			MatchMethod("GET").
+			MatchPath("/api/v1/customers/CUSTOMER_1/projected_usage").
+			MatchQuery("external_subscription_id=SUB_1&apply_taxes=false").
+			MockResponse(response)
+		defer server.Close()
+
+		result, err := server.Client().Customer().ProjectedUsage(context.Background(), "CUSTOMER_1", &CustomerUsageInput{
+			ExternalSubscriptionID: "SUB_1",
+		})
+		c.Assert(err == nil, qt.IsTrue)
+		chargeUsage := result.ChargesUsage[0]
+		c.Assert(chargeUsage.PresentationBreakdowns[0].Units, qt.Equals, "9.0")
+		c.Assert(chargeUsage.ProjectedPresentationBreakdowns[0].Units, qt.Equals, "18.0")
+		c.Assert(chargeUsage.Filters[0].ProjectedPresentationBreakdowns[0].Units, qt.Equals, "6.0")
+		c.Assert(chargeUsage.GroupedUsage[0].Filters[0].ProjectedUnits, qt.Equals, "4.0")
+		c.Assert(chargeUsage.GroupedUsage[0].ProjectedPresentationBreakdowns[0].PresentationBy["region"], qt.Equals, "eu")
+	})
+
+	t.Run("When marshaling presentation group keys", func(t *testing.T) {
+		c := qt.New(t)
+
+		chargeInput := ChargeInput{
+			Properties: map[string]interface{}{
+				"presentation_group_keys": []ChargePresentationGroupKey{
+					{
+						Value: "region",
+						Options: ChargePresentationGroupKeyOptions{
+							DisplayInInvoice: true,
+						},
+					},
+				},
+			},
+		}
+
+		payload, err := json.Marshal(chargeInput)
+		c.Assert(err, qt.IsNil)
+		c.Assert(string(payload), qt.Contains, `"presentation_group_keys"`)
+		c.Assert(string(payload), qt.Contains, `"display_in_invoice":true`)
+	})
 }
 
 func TestCustomerRequest_Get(t *testing.T) {

--- a/fee.go
+++ b/fee.go
@@ -157,9 +157,10 @@ type Fee struct {
 	FailedAt    time.Time `json:"failed_at,omitempty"`
 	RefundedAt  time.Time `json:"refunded_at,omitempty"`
 
-	Item               FeeItem             `json:"item,omitempty"`
-	AppliedTaxes       []FeeAppliedTax     `json:"applied_taxes,omitempty"`
-	PricingUnitDetails *PricingUnitDetails `json:"pricing_unit_details,omitempty"`
+	Item                   FeeItem                 `json:"item,omitempty"`
+	AppliedTaxes           []FeeAppliedTax         `json:"applied_taxes,omitempty"`
+	PricingUnitDetails     *PricingUnitDetails     `json:"pricing_unit_details,omitempty"`
+	PresentationBreakdowns []PresentationBreakdown `json:"presentation_breakdowns,omitempty"`
 }
 
 func (c *Client) Fee() *FeeRequest {

--- a/fee_test.go
+++ b/fee_test.go
@@ -1,0 +1,31 @@
+package lago_test
+
+import (
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	lt "github.com/getlago/lago-go-client/testing"
+)
+
+func TestFeeRequest_Get_WithPresentationBreakdowns(t *testing.T) {
+	c := qt.New(t)
+
+	server := lt.NewMockServer(c).
+		MatchMethod("GET").
+		MatchPath("/api/v1/fees/fee_123").
+		MockResponse(map[string]any{
+			"fee": map[string]any{
+				"presentation_breakdowns": []map[string]any{
+					{"presentation_by": map[string]any{"team": "engineering"}, "units": "9.0"},
+				},
+			},
+		})
+	defer server.Close()
+
+	result, err := server.Client().Fee().Get(context.Background(), "fee_123")
+	c.Assert(err == nil, qt.IsTrue)
+	c.Assert(result.PresentationBreakdowns[0].PresentationBy["team"], qt.Equals, "engineering")
+	c.Assert(result.PresentationBreakdowns[0].Units, qt.Equals, "9.0")
+}


### PR DESCRIPTION
This commit updates the client to support presentation group keys

We're changing the following structures to include the presentation_breakdowns:
- CustomerChargeUsage, including filters non grouped and grouped_usages
- CustomerProjectedChargeUsage, including filters, non grouped and grouped_usages + projected_presentation_breakdowns
- Fee object to include presentation_breakdowns

For filtering endpoints
- Updated the url params of CustomerUsage to support `filter_by_presentation` option.

Plan update/create can now send this payload to use presentation_group_keys:

```go
So plan create/update payloads can now send:
Properties: map[string]interface{}{
    "presentation_group_keys": []lago.ChargePresentationGroupKey{
        {
            Value: "region",
            Options: lago.ChargePresentationGroupKeyOptions{
                DisplayInInvoice: true,
            },
        },
    },
}
```

We're not changing the properties to be typed object properties to avoid breaking the API.