### PR TITLE
[ING-242] feat(wallets): add grants_target_top_up to recurring transaction rules

### DIFF
--- a/customer_wallet_test.go
+++ b/customer_wallet_test.go
@@ -46,6 +46,7 @@ var mockCustomerWalletResponse = `{
 			"transaction_metadata": [],
 			"transaction_name": "Recurring Transaction Rule",
 			"ignore_paid_top_up_limits": false,
+			"grants_target_top_up": true,
 			"payment_method": {
 				"payment_method_type": "card",
 				"payment_method_id": "pm_rule_123"
@@ -116,6 +117,7 @@ var mockCustomerWalletListResponse = `{
 			"transaction_metadata": [],
 			"transaction_name": "Recurring Transaction Rule",
 			"ignore_paid_top_up_limits": false,
+			"grants_target_top_up": true,
 			"payment_method": {
 				"payment_method_type": "card",
 				"payment_method_id": "pm_rule_123"
@@ -204,7 +206,8 @@ func TestCustomerWallet_Create(t *testing.T) {
 							"method": "fixed",
 							"expiration_at": "2026-12-31T23:59:59Z",
 							"transaction_name": "Recurring Transaction Rule",
-							"ignore_paid_top_up_limits": true
+							"ignore_paid_top_up_limits": true,
+							"grants_target_top_up": true
 						}
 					],
 					"applies_to": {
@@ -239,6 +242,7 @@ func TestCustomerWallet_Create(t *testing.T) {
 					ExpirationAt:          Ptr(time.Date(2026, 12, 31, 23, 59, 59, 0, time.UTC)),
 					TransactionName:       "Recurring Transaction Rule",
 					IgnorePaidTopUpLimits: Ptr(true),
+					GrantsTargetTopUp:     Ptr(true),
 				},
 			},
 			AppliesTo: AppliesTo{
@@ -267,6 +271,7 @@ func TestCustomerWallet_Create(t *testing.T) {
 		c.Assert(result.RecurringTransactionRules[0].Interval, qt.Equals, "monthly")
 		c.Assert(result.RecurringTransactionRules[0].TransactionName, qt.Equals, "Recurring Transaction Rule")
 		c.Assert(result.RecurringTransactionRules[0].IgnorePaidTopUpLimits, qt.Equals, false)
+		c.Assert(result.RecurringTransactionRules[0].GrantsTargetTopUp, qt.DeepEquals, Ptr(true))
 		c.Assert(result.RecurringTransactionRules[0].ExpirationAt, qt.DeepEquals, Ptr(time.Date(2026, 12, 31, 23, 59, 59, 0, time.UTC)))
 		c.Assert(result.AppliesTo.FeeTypes, qt.DeepEquals, []string{"charge"})
 		c.Assert(result.AppliesTo.BillableMetricCodes, qt.DeepEquals, []string{"bm1"})
@@ -458,6 +463,50 @@ func TestCustomerWallet_Update(t *testing.T) {
 		c.Assert(result.BalanceCents, qt.Equals, 20000)
 		c.Assert(result.Status, qt.Equals, Status("active"))
 		c.Assert(result.Currency, qt.Equals, Currency("USD"))
+	})
+
+	t.Run("When updating a target rule that grants top-up credits", func(t *testing.T) {
+		c := qt.New(t)
+
+		server := lt.NewMockServer(c).
+			MatchMethod("PUT").
+			MatchPath("/api/v1/customers/customer_id/wallets/wallet_code").
+			MatchJSONBody(`{
+				"wallet": {
+					"name": "updated wallet name",
+					"applies_to": {},
+					"recurring_transaction_rules": [
+						{
+							"lago_id": "00000000-0000-0000-0000-000000000000",
+							"trigger": "interval",
+							"interval": "monthly",
+							"method": "target",
+							"target_ongoing_balance": "200.00",
+							"grants_target_top_up": true
+						}
+					]
+				}
+			}`).
+			MockResponse(mockCustomerWalletResponse)
+		defer server.Close()
+
+		result, err := server.Client().CustomerWallet().Update(context.Background(), "customer_id", "wallet_code", &WalletInput{
+			Name: "updated wallet name",
+			RecurringTransactionRules: []RecurringTransactionRuleInput{
+				{
+					Trigger:              "interval",
+					Interval:             "monthly",
+					Method:               "target",
+					TargetOngoingBalance: "200.00",
+					GrantsTargetTopUp:    Ptr(true),
+				},
+			},
+		})
+
+		c.Assert(err == nil, qt.IsTrue)
+		c.Assert(result, qt.IsNotNil)
+		c.Assert(len(result.RecurringTransactionRules), qt.Equals, 1)
+		c.Assert(result.RecurringTransactionRules[0].GrantsTargetTopUp, qt.DeepEquals, Ptr(true))
 	})
 }
 

--- a/wallet.go
+++ b/wallet.go
@@ -31,6 +31,7 @@ type RecurringTransactionRuleInput struct {
 	TransactionMetadata              []WalletTransactionMetadata `json:"transaction_metadata,omitempty"`
 	TransactionName                  string                      `json:"transaction_name,omitempty"`
 	IgnorePaidTopUpLimits            *bool                       `json:"ignore_paid_top_up_limits,omitempty"`
+	GrantsTargetTopUp                *bool                       `json:"grants_target_top_up,omitempty"`
 	PaymentMethod                    *PaymentMethodInput         `json:"payment_method,omitempty"`
 	InvoiceCustomSection             *InvoiceCustomSectionInput  `json:"invoice_custom_section,omitempty"`
 }
@@ -52,6 +53,7 @@ type RecurringTransactionRuleResponse struct {
 	TransactionMetadata              []WalletTransactionMetadata   `json:"transaction_metadata,omitempty"`
 	TransactionName                  string                        `json:"transaction_name,omitempty"`
 	IgnorePaidTopUpLimits            bool                          `json:"ignore_paid_top_up_limits"`
+	GrantsTargetTopUp                *bool                         `json:"grants_target_top_up,omitempty"`
 	PaymentMethod                    *PaymentMethodInput           `json:"payment_method,omitempty"`
 	AppliedInvoiceCustomSections     []AppliedInvoiceCustomSection `json:"applied_invoice_custom_sections,omitempty"`
 }

--- a/wallet_test.go
+++ b/wallet_test.go
@@ -49,6 +49,7 @@ var mockWalletResponse = `{
 			"transaction_metadata": [],
 			"transaction_name": "Recurring Transaction Rule",
 			"ignore_paid_top_up_limits": false,
+			"grants_target_top_up": true,
 			"payment_method": {
 				"payment_method_type": "card",
 				"payment_method_id": "pm_rule_123"
@@ -119,6 +120,7 @@ var mockWalletListResponse = `{
 			"transaction_metadata": [],
 			"transaction_name": "Recurring Transaction Rule",
 			"ignore_paid_top_up_limits": false,
+			"grants_target_top_up": true,
 			"payment_method": {
 				"payment_method_type": "card",
 				"payment_method_id": "pm_rule_123"
@@ -209,7 +211,8 @@ func TestWallet_Create(t *testing.T) {
 							"method": "fixed",
 							"expiration_at": "2026-12-31T23:59:59Z",
 							"transaction_name": "Recurring Transaction Rule",
-							"ignore_paid_top_up_limits": true
+							"ignore_paid_top_up_limits": true,
+							"grants_target_top_up": true
 						}
 					],
 					"applies_to": {
@@ -245,6 +248,7 @@ func TestWallet_Create(t *testing.T) {
 					ExpirationAt:          Ptr(time.Date(2026, 12, 31, 23, 59, 59, 0, time.UTC)),
 					TransactionName:       "Recurring Transaction Rule",
 					IgnorePaidTopUpLimits: Ptr(true),
+					GrantsTargetTopUp:     Ptr(true),
 				},
 			},
 			AppliesTo: AppliesTo{
@@ -273,6 +277,7 @@ func TestWallet_Create(t *testing.T) {
 		c.Assert(result.RecurringTransactionRules[0].Interval, qt.Equals, "monthly")
 		c.Assert(result.RecurringTransactionRules[0].TransactionName, qt.Equals, "Recurring Transaction Rule")
 		c.Assert(result.RecurringTransactionRules[0].IgnorePaidTopUpLimits, qt.Equals, false)
+		c.Assert(result.RecurringTransactionRules[0].GrantsTargetTopUp, qt.DeepEquals, Ptr(true))
 		c.Assert(result.RecurringTransactionRules[0].ExpirationAt, qt.DeepEquals, Ptr(time.Date(2026, 12, 31, 23, 59, 59, 0, time.UTC)))
 		c.Assert(result.AppliesTo.FeeTypes, qt.DeepEquals, []string{"charge"})
 		c.Assert(result.AppliesTo.BillableMetricCodes, qt.DeepEquals, []string{"bm1"})
@@ -461,6 +466,50 @@ func TestWallet_Update(t *testing.T) {
 		c.Assert(result.BalanceCents, qt.Equals, 20000)
 		c.Assert(result.Status, qt.Equals, Status("active"))
 		c.Assert(result.Currency, qt.Equals, Currency("USD"))
+	})
+
+	t.Run("When updating a target rule that grants top-up credits", func(t *testing.T) {
+		c := qt.New(t)
+
+		server := lt.NewMockServer(c).
+			MatchMethod("PUT").
+			MatchPath("/api/v1/wallets/wallet_id").
+			MatchJSONBody(`{
+				"wallet": {
+					"name": "updated wallet name",
+					"applies_to": {},
+					"recurring_transaction_rules": [
+						{
+							"lago_id": "00000000-0000-0000-0000-000000000000",
+							"trigger": "interval",
+							"interval": "monthly",
+							"method": "target",
+							"target_ongoing_balance": "200.00",
+							"grants_target_top_up": true
+						}
+					]
+				}
+			}`).
+			MockResponse(mockWalletResponse)
+		defer server.Close()
+
+		result, err := server.Client().Wallet().Update(context.Background(), &WalletInput{
+			Name: "updated wallet name",
+			RecurringTransactionRules: []RecurringTransactionRuleInput{
+				{
+					Trigger:              "interval",
+					Interval:             "monthly",
+					Method:               "target",
+					TargetOngoingBalance: "200.00",
+					GrantsTargetTopUp:    Ptr(true),
+				},
+			},
+		}, "wallet_id")
+
+		c.Assert(err == nil, qt.IsTrue)
+		c.Assert(result, qt.IsNotNil)
+		c.Assert(len(result.RecurringTransactionRules), qt.Equals, 1)
+		c.Assert(result.RecurringTransactionRules[0].GrantsTargetTopUp, qt.DeepEquals, Ptr(true))
 	})
 }
 


### PR DESCRIPTION
## Context

Wallet recurring transaction rules of type `target` previously always created a paid top-up; there was no way to grant free credits through a target rule. The API now supports this via a nullable boolean `grants_target_top_up` on the recurring transaction rule (getlago/lago-api#5755). On a `target` rule, `true` makes the periodic gap-fill grant free credits to reach the target balance instead of creating a paid top-up; `false`, the default for target rules, keeps the current paid behaviour. The field is `null` for `fixed` rules.

## Description

Exposes `grants_target_top_up` in the SDK so consumers can set it on create/update and read it from responses:

- Adds `GrantsTargetTopUp *bool` to `RecurringTransactionRuleInput` and `RecurringTransactionRuleResponse`. A pointer is used so a `fixed` rule's `null` is preserved rather than silently coerced to `false`.
- Adds create and update coverage (customer-scoped and top-level) asserting the field is forwarded in the request body and parsed from the response.

No version bump: released separately (Go modules tag at release), per repo convention.

## How to try locally

```
go test ./...
```

