### PR TITLE
fix(customers): Suppress integration customers ID placeholder when not present

### DIFF
--- a/customer.go
+++ b/customer.go
@@ -206,6 +206,20 @@ type IntegrationCustomer struct {
 	SyncWithProvider   bool            `json:"sync_with_provider,omitempty"`
 }
 
+func (ic IntegrationCustomer) MarshalJSON() ([]byte, error) {
+	type Alias IntegrationCustomer
+	out := &struct {
+		Alias
+		LagoID *uuid.UUID `json:"id,omitempty"`
+	}{
+		Alias: Alias(ic),
+	}
+	if ic.LagoID != uuid.Nil {
+		out.LagoID = &ic.LagoID
+	}
+	return json.Marshal(out)
+}
+
 type IntegrationCustomersResponse struct {
 	LagoID             uuid.UUID       `json:"lago_id,omitempty"`
 	ExternalCustomerId string          `json:"external_customer_id,omitempty"`

--- a/customer_test.go
+++ b/customer_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+	"github.com/google/uuid"
 
 	. "github.com/getlago/lago-go-client"
 	lt "github.com/getlago/lago-go-client/testing"
@@ -351,6 +352,107 @@ var mockCustomerCheckoutUrlResponse = map[string]any{
 		"payment_provider_code": "Stripe Provider",
 		"checkout_url":          "https://example.com",
 	},
+}
+
+var mockCustomerCreateResponse = `{
+	"customer": {
+		"lago_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
+		"external_id": "CUSTOMER_1"
+	}
+}`
+
+func TestCustomerRequest_Create(t *testing.T) {
+	t.Run("When integration_customers has no id, the placeholder UUID is omitted", func(t *testing.T) {
+		c := qt.New(t)
+
+		server := lt.NewMockServer(c).
+			MatchMethod("POST").
+			MatchPath("/api/v1/customers").
+			MatchJSONBody(`{
+				"customer": {
+					"external_id": "CUSTOMER_1",
+					"billing_configuration": {
+						"subscription_invoice_issuing_date_anchor": null,
+						"subscription_invoice_issuing_date_adjustment": null
+					},
+					"shipping_address": {},
+					"integration_customers": [
+						{
+							"external_customer_id": "netsuite_123",
+							"integration_type": "netsuite",
+							"integration_code": "netsuite_integration",
+							"sync_with_provider": true
+						}
+					]
+				}
+			}`).
+			MockResponse(mockCustomerCreateResponse)
+		defer server.Close()
+
+		result, err := server.Client().Customer().Create(context.Background(), &CustomerInput{
+			ExternalID: "CUSTOMER_1",
+			IntegrationCustomers: []IntegrationCustomer{
+				{
+					ExternalCustomerId: "netsuite_123",
+					IntegrationType:    IntegrationNetsuite,
+					IntegrationCode:    "netsuite_integration",
+					SyncWithProvider:   true,
+				},
+			},
+		})
+		c.Assert(err == nil, qt.IsTrue)
+		c.Assert(result, qt.DeepEquals, &Customer{
+			LagoID:     uuid.MustParse("1a901a90-1a90-1a90-1a90-1a901a901a90"),
+			ExternalID: "CUSTOMER_1",
+		})
+	})
+
+	t.Run("When integration_customers includes a real id, it is sent", func(t *testing.T) {
+		c := qt.New(t)
+
+		server := lt.NewMockServer(c).
+			MatchMethod("POST").
+			MatchPath("/api/v1/customers").
+			MatchJSONBody(`{
+				"customer": {
+					"external_id": "CUSTOMER_1",
+					"billing_configuration": {
+						"subscription_invoice_issuing_date_anchor": null,
+						"subscription_invoice_issuing_date_adjustment": null
+					},
+					"shipping_address": {},
+					"integration_customers": [
+						{
+							"id": "2b902b90-2b90-2b90-2b90-2b902b902b90",
+							"external_customer_id": "netsuite_123",
+							"integration_type": "netsuite",
+							"integration_code": "netsuite_integration",
+							"sync_with_provider": true
+						}
+					]
+				}
+			}`).
+			MockResponse(mockCustomerCreateResponse)
+		defer server.Close()
+
+		result, err := server.Client().Customer().Create(context.Background(), &CustomerInput{
+			ExternalID: "CUSTOMER_1",
+			IntegrationCustomers: []IntegrationCustomer{
+				{
+					LagoID:             uuid.MustParse("2b902b90-2b90-2b90-2b90-2b902b902b90"),
+					ExternalCustomerId: "netsuite_123",
+					IntegrationType:    IntegrationNetsuite,
+					IntegrationCode:    "netsuite_integration",
+					SyncWithProvider:   true,
+				},
+			},
+		})
+		c.Assert(err == nil, qt.IsTrue)
+		c.Assert(result, qt.DeepEquals, &Customer{
+			LagoID:     uuid.MustParse("1a901a90-1a90-1a90-1a90-1a901a901a90"),
+			ExternalID: "CUSTOMER_1",
+		})
+	})
 }
 
 func TestCustomerRequest_GetInvoiceList(t *testing.T) {


### PR DESCRIPTION
### Summary

`IntegrationCustomer.LagoID` is typed `uuid.UUID`, which is a `[16]byte` array. Go's `encoding/json` `omitempty` option has **no effect on array types**, so an unset `LagoID` was not omitted — it serialized as the zero UUID `00000000-0000-0000-0000-000000000000`:

```json
{
  "customer": {
    "external_id": "customer-external-id",
    "integration_customers": [
      {
        "id": "00000000-0000-0000-0000-000000000000",
        "external_customer_id": "netsuite_123",
        "integration_type": "netsuite",
        "integration_code": "netsuite_integration",
        "sync_with_provider": true
      }
    ]
  }
}
```

This PR makes the client omit `id` entirely when `LagoID` is unset.

### Scope

This is a **correctness / hygiene fix**, not the fix for duplicate NetSuite/Anrok customers.

The duplicate-customer issue was traced to the backend (`IntegrationCustomers::CreateOrUpdateBatchService#sanitize_integration_customers`), which destroyed and recreated the integration-customer link whenever the payload's `id` didn't match the stored record — and an **omitted id behaved identically to the all-zeros placeholder** (both fail the match and trigger destroy + recreate). Verified live against `api.lago.dev`: before the backend change the link id changed on every upsert (placeholder *and* omitted); after it, the link is preserved across repeated calls. **That backend change is the actual fix.**

This SDK change is still worth merging because:

- It fixes a real serialization bug — `omitempty` silently does nothing on the `uuid.UUID` array type.
- The client should never emit a meaningless all-zeros UUID as an `id`.

It just should not be merged under the expectation that it resolves the duplicate customers on its own.

### Fix

Add a custom `MarshalJSON` to `IntegrationCustomer` that omits `id` when `LagoID` is the zero UUID. The public field type stays `uuid.UUID`, so this is **not a breaking change** for callers — only the serialized output changes.

```go
customer, err := client.Customer().Create(ctx, &lago.CustomerInput{
    ExternalID: "customer-external-id",
    IntegrationCustomers: []lago.IntegrationCustomer{
        {
            ExternalCustomerId: "netsuite_123",
            IntegrationType:    lago.IntegrationNetsuite,
            IntegrationCode:    "netsuite_integration",
            SyncWithProvider:   true,
        },
    },
})
```

The `id` field is now omitted entirely from the request body:

```json
{
  "customer": {
    "external_id": "customer-external-id",
    "integration_customers": [
      {
        "external_customer_id": "netsuite_123",
        "integration_type": "netsuite",
        "integration_code": "netsuite_integration",
        "sync_with_provider": true
      }
    ]
  }
}
```

When a real `LagoID` is provided, it is preserved and sent as before:

```go
IntegrationCustomers: []lago.IntegrationCustomer{
    {
        LagoID:             uuid.MustParse("2b902b90-2b90-2b90-2b90-2b902b902b90"),
        ExternalCustomerId: "netsuite_123",
        IntegrationType:    lago.IntegrationNetsuite,
        IntegrationCode:    "netsuite_integration",
        SyncWithProvider:   true,
    },
}
// => "id": "2b902b90-2b90-2b90-2b90-2b902b902b90" is included in the request body
```

### Tests

Added `TestCustomerRequest_Create` with two cases that assert the outgoing request body via `MatchJSONBody`:

- **`id` omitted when `LagoID` is unset** — the request body must not contain the placeholder `00000000-0000-0000-0000-000000000000`.
- **`id` sent when `LagoID` is set** — confirms a real id is still serialized.
