### PR TITLE
fix: rename tax JSON field to taxes

### DIFF
--- a/add_on.go
+++ b/add_on.go
@@ -50,7 +50,7 @@ type AddOn struct {
 	AmountCents    int      `json:"amount_cents,omitempty"`
 	AmountCurrency Currency `json:"amount_currency,omitempty"`
 
-	Taxes []Tax `json:"tax,omitempty"`
+	Taxes []Tax `json:"taxes,omitempty"`
 
 	CreatedAt time.Time `json:"created_at,omitempty"`
 }

--- a/charge.go
+++ b/charge.go
@@ -48,7 +48,7 @@ type Charge struct {
 	AppliedPricingUnit   *AppliedPricingUnit    `json:"applied_pricing_unit,omitempty"`
 	AcceptsTargetWallet  *bool                  `json:"accepts_target_wallet,omitempty"`
 
-	Taxes []Tax `json:"tax,omitempty"`
+	Taxes []Tax `json:"taxes,omitempty"`
 }
 
 // Standalone charge CRUD types

--- a/plan.go
+++ b/plan.go
@@ -100,7 +100,7 @@ type MinimumCommitment struct {
 	CreatedAt          time.Time    `json:"created_at,omitempty"`
 	UpdatedAt          time.Time    `json:"updated_at,omitempty"`
 
-	Taxes []Tax `json:"tax,omitempty"`
+	Taxes []Tax `json:"taxes,omitempty"`
 }
 
 type Plan struct {


### PR DESCRIPTION
Rename tax JSON field to taxes on plan, charge, and add-on types

Updates the JSON serialization tags for the Taxes field from tax to taxes in AddOn, Charge, and MinimumCommitment, so the Go client matches the Lago API response format.