### PR TITLE
feat: Add support for multi-currency on customer billing objects

### DIFF
--- a/dunning_campaign.go
+++ b/dunning_campaign.go
@@ -1,8 +1,14 @@
 package lago
 
 type DunningCampaign struct {
-	CustomerExternalID     string   `json:"customer_external_id"`
-	DunningCampaignCode    string   `json:"dunning_campaign_code"`
-	OverdueBalanceCents    int      `json:"overdue_balance_cents"`
-	OverdueBalanceCurrency Currency `json:"overdue_balance_currency"`
+	CustomerExternalID     string                          `json:"customer_external_id"`
+	DunningCampaignCode    string                          `json:"dunning_campaign_code"`
+	OverdueBalanceCents    int                             `json:"overdue_balance_cents"`
+	OverdueBalanceCurrency Currency                        `json:"overdue_balance_currency"`
+	OverdueBalances        []DunningCampaignOverdueBalance `json:"overdue_balances,omitempty"`
+}
+
+type DunningCampaignOverdueBalance struct {
+	AmountCents int      `json:"amount_cents"`
+	Currency    Currency `json:"currency"`
 }

--- a/payment_request.go
+++ b/payment_request.go
@@ -26,7 +26,7 @@ type PaymentRequestListInput struct {
 	ExternalCustomerID string   `url:"external_customer_id,omitempty"`
 	PaymentStatus      string   `url:"payment_status,omitempty"`
 	BillingEntityCodes []string `url:"billing_entity_codes[],omitempty"`
-	Currency           string `json:"currency,omitempty"`
+	Currency           Currency `url:"currency,omitempty"`
 }
 
 type PaymentRequest struct {

--- a/payment_request.go
+++ b/payment_request.go
@@ -26,6 +26,7 @@ type PaymentRequestListInput struct {
 	ExternalCustomerID string   `url:"external_customer_id,omitempty"`
 	PaymentStatus      string   `url:"payment_status,omitempty"`
 	BillingEntityCodes []string `url:"billing_entity_codes[],omitempty"`
+	Currency           string `json:"currency,omitempty"`
 }
 
 type PaymentRequest struct {

--- a/subscription.go
+++ b/subscription.go
@@ -119,6 +119,7 @@ type SubscriptionTerminateInput struct {
 type SubscriptionListInput struct {
 	ExternalCustomerID string               `url:"external_customer_id,omitempty"`
 	PlanCode           string               `url:"plan_code,omitempty"`
+	Currency           string               `url:"currency,omitempty"`
 	PerPage            *int                 `url:"per_page,omitempty"`
 	Page               *int                 `url:"page,omitempty"`
 	Status             []SubscriptionStatus `url:"status[],omitempty"`

--- a/subscription.go
+++ b/subscription.go
@@ -119,7 +119,7 @@ type SubscriptionTerminateInput struct {
 type SubscriptionListInput struct {
 	ExternalCustomerID string               `url:"external_customer_id,omitempty"`
 	PlanCode           string               `url:"plan_code,omitempty"`
-	Currency           string               `url:"currency,omitempty"`
+	Currency           Currency             `url:"currency,omitempty"`
 	PerPage            *int                 `url:"per_page,omitempty"`
 	Page               *int                 `url:"page,omitempty"`
 	Status             []SubscriptionStatus `url:"status[],omitempty"`

--- a/testing/fixtures/webhooks/dunning_campaign_finished.json
+++ b/testing/fixtures/webhooks/dunning_campaign_finished.json
@@ -6,6 +6,12 @@
     "customer_external_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
     "dunning_campaign_code": "Campaign_Code",
     "overdue_balance_cents": 100,
-    "overdue_balance_currency": "EUR"
+    "overdue_balance_currency": "EUR",
+    "overdue_balances": [
+      {
+        "amount_cents": 100,
+        "currency": "EUR"
+      }
+    ]
   }
 }

--- a/wallet.go
+++ b/wallet.go
@@ -98,6 +98,7 @@ type WalletListInput struct {
 	Page               *int     `url:"page,omitempty"`
 	ExternalCustomerID string   `url:"external_customer_id,omitempty"`
 	BillingEntityCodes []string `url:"billing_entity_codes[],omitempty"`
+	Currency           string `json:"currency,omitempty"`
 }
 
 type WalletResult struct {

--- a/wallet.go
+++ b/wallet.go
@@ -98,7 +98,7 @@ type WalletListInput struct {
 	Page               *int     `url:"page,omitempty"`
 	ExternalCustomerID string   `url:"external_customer_id,omitempty"`
 	BillingEntityCodes []string `url:"billing_entity_codes[],omitempty"`
-	Currency           string `json:"currency,omitempty"`
+	Currency           Currency `url:"currency,omitempty"`
 }
 
 type WalletResult struct {

--- a/wallet_test.go
+++ b/wallet_test.go
@@ -383,6 +383,7 @@ func TestWallet_GetList(t *testing.T) {
 
 		result, err := server.Client().Wallet().GetList(context.Background(), &WalletListInput{
 			ExternalCustomerID: "12345",
+			Currency:           USD,
 			PerPage:            Ptr(10),
 			Page:               Ptr(1),
 		})

--- a/webhook_message_test.go
+++ b/webhook_message_test.go
@@ -119,8 +119,11 @@ var tests = []struct {
 	{
 		fixture: "dunning_campaign_finished",
 		test: func(object any) bool {
-			_, ok := object.(*DunningCampaign)
-			return ok
+			dunningCampaign, ok := object.(*DunningCampaign)
+			return ok &&
+				len(dunningCampaign.OverdueBalances) == 1 &&
+				dunningCampaign.OverdueBalances[0].AmountCents == 100 &&
+				dunningCampaign.OverdueBalances[0].Currency == EUR
 		},
 	},
 	{


### PR DESCRIPTION
## Add multi-currency support

Additive, backward-compatible support for the Lago API multi-currency feature.

### Changes

1. **`currency` list filter on three endpoints**

   Added an optional `Currency` filter (typed `Currency` enum, matching the existing `/invoices` and `/credit_notes` filters) to:
   - `SubscriptionListInput` (subscription.go) — `url:"currency,omitempty"`
   - `WalletListInput` (wallet.go) — `json:"currency,omitempty"`
   - `PaymentRequestListInput` (payment_request.go) — `json:"currency,omitempty"`

   (Built on a cherry-picked commit that introduced these as `string`; switched to the `Currency` type for consistency with the existing currency filters.)

2. **`dunning_campaign.finished` webhook — `overdue_balances`**

   Added `OverdueBalances []DunningCampaignOverdueBalance` to the `DunningCampaign` webhook struct (dunning_campaign.go), alongside the existing `overdue_balance_cents` / `overdue_balance_currency` fields. New struct:

   ```go
   type DunningCampaignOverdueBalance struct {
       AmountCents int      `json:"amount_cents"`
       Currency    Currency `json:"currency"`
   }