### PR TITLE
feat: Add external_id to Customer and Subscription GetList

### DIFF
--- a/customer.go
+++ b/customer.go
@@ -153,6 +153,7 @@ type CustomerListInput struct {
 	Page    *int `url:"page,omitempty,string"`
 
 	SearchTerm                 string                    `url:"search_term,omitempty"`
+	ExternalID                 string                    `url:"external_id,omitempty"`
 	Countries                  []string                  `url:"countries[],omitempty"`
 	States                     []string                  `url:"states[],omitempty"`
 	Zipcodes                   []string                  `url:"zipcodes[],omitempty"`
@@ -421,8 +422,9 @@ type CustomerSubscriptionListInput struct {
 	PerPage *int `url:"per_page,omitempty"`
 	Page    *int `url:"page,omitempty"`
 
-	PlanCode string               `url:"plan_code,omitempty"`
-	Status   []SubscriptionStatus `url:"status[],omitempty"`
+	PlanCode   string               `url:"plan_code,omitempty"`
+	ExternalID string               `url:"external_id,omitempty"`
+	Status     []SubscriptionStatus `url:"status[],omitempty"`
 }
 
 type Customer struct {

--- a/customer_test.go
+++ b/customer_test.go
@@ -753,17 +753,18 @@ func TestCustomerRequest_GetSubscriptionList(t *testing.T) {
 		server := lt.NewMockServer(c).
 			MatchMethod("GET").
 			MatchPath("/api/v1/customers/CUSTOMER_1/subscriptions").
-			MatchQuery("per_page=10&page=1&plan_code=premium&status[]=active&status[]=terminated").
+			MatchQuery("per_page=10&page=1&external_id=5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba&plan_code=premium&status[]=active&status[]=terminated").
 			MockResponse(mockCustomerSubscriptionListResponse)
 		defer server.Close()
 
 		perPage := 10
 		page := 1
 		result, err := server.Client().Customer().GetSubscriptionList(context.Background(), "CUSTOMER_1", &CustomerSubscriptionListInput{
-			PerPage:  &perPage,
-			Page:     &page,
-			PlanCode: "premium",
-			Status:   []SubscriptionStatus{SubscriptionStatusActive, SubscriptionStatusTerminated},
+			PerPage:    &perPage,
+			Page:       &page,
+			ExternalID: "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+			PlanCode:   "premium",
+			Status:     []SubscriptionStatus{SubscriptionStatusActive, SubscriptionStatusTerminated},
 		})
 		c.Assert(err == nil, qt.IsTrue)
 		c.Assert(result.Subscriptions, qt.HasLen, 1)
@@ -820,6 +821,7 @@ func TestCustomerRequest_GetList(t *testing.T) {
 			MatchQuery("per_page=5" +
 				"&page=1" +
 				"&search_term=acme" +
+				"&external_id=CUSTOMER_1" +
 				"&countries[]=US" +
 				"&countries[]=CA" +
 				"&states[]=CA" +
@@ -849,6 +851,7 @@ func TestCustomerRequest_GetList(t *testing.T) {
 			PerPage:                    &perPage,
 			Page:                       &page,
 			SearchTerm:                 "acme",
+			ExternalID:                 "CUSTOMER_1",
 			Countries:                  []string{"US", "CA"},
 			States:                     []string{"CA", "NY"},
 			Zipcodes:                   []string{"91364", "94102"},

--- a/subscription.go
+++ b/subscription.go
@@ -116,6 +116,7 @@ type SubscriptionTerminateInput struct {
 }
 
 type SubscriptionListInput struct {
+	ExternalID         string               `url:"external_id,omitempty"`
 	ExternalCustomerID string               `url:"external_customer_id,omitempty"`
 	PlanCode           string               `url:"plan_code,omitempty"`
 	PerPage            *int                 `url:"per_page,omitempty"`

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -263,6 +263,266 @@ var mockSubscriptionResponse = `{
   }
 }`
 
+var mockSubscriptionListResponse = `{
+  "subscriptions": [
+		{
+			"lago_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
+			"external_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+			"lago_customer_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
+			"external_customer_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+			"billing_time": "anniversary",
+			"name": "Repository A",
+			"plan_code": "premium",
+			"plan_amount_cents": 10000,
+			"plan_amount_currency": "USD",
+			"status": "terminated",
+			"created_at": "2022-08-08T00:00:00Z",
+			"canceled_at": "2022-09-14T16:35:31Z",
+			"started_at": "2022-08-08T00:00:00Z",
+			"ending_at": "2022-10-08T00:00:00Z",
+			"subscription_at": "2022-08-08T00:00:00Z",
+			"terminated_at": "2022-09-14T16:35:31Z",
+			"previous_plan_code": null,
+			"next_plan_code": null,
+			"downgrade_plan_date": "2022-04-30",
+			"trial_ended_at": "2022-08-08T00:00:00Z",
+			"on_termination_credit_note": "skip",
+			"on_termination_invoice": "skip",
+			"consolidate_invoice": true,
+			"payment_method": {
+				"payment_method_type": "card",
+				"payment_method_id": "pm_123456"
+			},
+			"current_billing_period_started_at": "2022-08-08T00:00:00Z",
+			"current_billing_period_ending_at": "2022-09-08T00:00:00Z",
+			"applied_invoice_custom_sections": [
+				{
+					"lago_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
+					"invoice_custom_section_id": "2b902b90-2b90-2b90-2b90-2b902b902b90",
+					"created_at": "2022-08-08T00:00:00Z",
+					"invoice_custom_section": {
+						"lago_id": "2b902b90-2b90-2b90-2b90-2b902b902b90",
+						"code": "section_code",
+						"name": "Section Name",
+						"description": "Section description",
+						"details": "Section details",
+						"display_name": "Display Name"
+					}
+				}
+			],
+			"plan": {
+				"lago_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
+				"name": "Startup",
+				"invoice_display_name": "Startup plan",
+				"created_at": "2023-06-27T19:43:42Z",
+				"code": "startup",
+				"interval": "monthly",
+				"description": "",
+				"amount_cents": 10000,
+				"amount_currency": "USD",
+				"trial_period": 5,
+				"pay_in_advance": true,
+				"bill_charges_monthly": null,
+				"minimum_commitment": {
+					"lago_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
+					"plan_code": "premium",
+					"amount_cents": 100000,
+					"invoice_display_name": "Minimum Commitment (C1)",
+					"interval": "monthly",
+					"created_at": "2022-04-29T08:59:51Z",
+					"updated_at": "2022-04-29T08:59:51Z",
+					"taxes": [
+						{
+							"lago_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
+							"name": "TVA",
+							"code": "french_standard_vat",
+							"description": "French standard VAT",
+							"rate": 20,
+							"applied_to_organization": true,
+							"created_at": "2023-07-06T14:35:58Z"
+						}
+					]
+				},
+				"charges": [
+					{
+						"lago_id": "1a901a90-1a90-1a90-1a90-1a901a901a91",
+						"lago_billable_metric_id": "1a901a90-1a90-1a90-1a90-1a901a901a91",
+						"billable_metric_code": "requests",
+						"created_at": "2023-06-27T19:43:42Z",
+						"charge_model": "package",
+						"invoiceable": true,
+						"invoice_display_name": "Setup",
+						"pay_in_advance": false,
+						"regroup_paid_fees": null,
+						"prorated": false,
+						"min_amount_cents": 3000,
+						"properties": {
+							"amount": "30",
+							"free_units": 100,
+							"package_size": 1000
+						},
+						"filters": []
+					},
+					{
+						"lago_id": "1a901a90-1a90-1a90-1a90-1a901a901a92",
+						"lago_billable_metric_id": "1a901a90-1a90-1a90-1a90-1a901a901a92",
+						"billable_metric_code": "cpu",
+						"created_at": "2023-06-27T19:43:42Z",
+						"charge_model": "graduated",
+						"invoiceable": true,
+						"invoice_display_name": "Setup",
+						"pay_in_advance": false,
+						"prorated": false,
+						"min_amount_cents": 0,
+						"properties": {
+							"graduated_ranges": [
+								{
+									"from_value": 0,
+									"to_value": 10,
+									"flat_amount": "10",
+									"per_unit_amount": "0.5"
+								},
+								{
+									"from_value": 11,
+									"to_value": null,
+									"flat_amount": "0",
+									"per_unit_amount": "0.4"
+								}
+							]
+						},
+						"filters": []
+					},
+					{
+						"lago_id": "1a901a90-1a90-1a90-1a90-1a901a901a93",
+						"lago_billable_metric_id": "1a901a90-1a90-1a90-1a90-1a901a901a93",
+						"billable_metric_code": "seats",
+						"created_at": "2023-06-27T19:43:42Z",
+						"charge_model": "standard",
+						"invoiceable": true,
+						"invoice_display_name": "Setup",
+						"pay_in_advance": true,
+						"prorated": false,
+						"min_amount_cents": 0,
+						"properties": {},
+						"filters": [
+							{
+								"invoice_display_name": "Europe",
+								"properties": {
+									"amount": "10"
+								},
+								"values": {
+									"region": [
+										"Europe"
+									]
+								}
+							},
+							{
+								"invoice_display_name": "USA",
+								"properties": {
+									"amount": "5"
+								},
+								"values": {
+									"region": [
+										"USA"
+									]
+								}
+							},
+							{
+								"invoice_display_name": "Africa",
+								"properties": {
+									"amount": "8"
+								},
+								"values": {
+									"region": [
+										"Africa"
+									]
+								}
+							}
+						]
+					},
+					{
+						"lago_id": "1a901a90-1a90-1a90-1a90-1a901a901a94",
+						"lago_billable_metric_id": "1a901a90-1a90-1a90-1a90-1a901a901a94",
+						"billable_metric_code": "storage",
+						"created_at": "2023-06-27T19:43:42Z",
+						"charge_model": "volume",
+						"invoiceable": true,
+						"invoice_display_name": "Setup",
+						"pay_in_advance": false,
+						"prorated": false,
+						"min_amount_cents": 0,
+						"properties": {
+							"volume_ranges": [
+								{
+									"from_value": 0,
+									"to_value": 100,
+									"flat_amount": "0",
+									"per_unit_amount": "0"
+								},
+								{
+									"from_value": 101,
+									"to_value": null,
+									"flat_amount": "0",
+									"per_unit_amount": "0.5"
+								}
+							]
+						},
+						"filters": []
+					},
+					{
+						"lago_id": "1a901a90-1a90-1a90-1a90-1a901a901a95",
+						"lago_billable_metric_id": "1a901a90-1a90-1a90-1a90-1a901a901a95",
+						"billable_metric_code": "payments",
+						"created_at": "2023-06-27T19:43:42Z",
+						"charge_model": "percentage",
+						"invoiceable": false,
+						"invoice_display_name": "Setup",
+						"pay_in_advance": true,
+						"regroup_paid_fees": "invoice",
+						"prorated": false,
+						"min_amount_cents": 0,
+						"properties": {
+							"rate": "1",
+							"fixed_amount": "0.5",
+							"free_units_per_events": 5,
+							"free_units_per_total_aggregation": "500"
+						},
+						"filters": []
+					}
+				],
+				"taxes": [
+					{
+						"lago_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
+						"name": "TVA",
+						"code": "french_standard_vat",
+						"description": "French standard VAT",
+						"rate": 20,
+						"applied_to_organization": true,
+						"created_at": "2023-07-06T14:35:58Z"
+					}
+				],
+				"usage_thresholds": [
+					{
+						"lago_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
+						"threshold_display_name": "Threshold 1",
+						"amount_cents": 10000,
+						"recurring": true,
+						"created_at": "2023-06-27T19:43:42Z",
+						"updated_at": "2023-06-27T19:43:42Z"
+					}
+				]
+			}
+		}
+	],
+	"meta": {
+		"current_page": 1,
+		"next_page": 0,
+		"prev_page": 0,
+		"total_pages": 1,
+		"total_count": 1
+	}
+}`
+
 func assertSubscriptionTerminateResponse(c *qt.C, subscription *Subscription) {
 	c.Assert(subscription.OnTerminationCreditNote, qt.Equals, OnTerminationCreditNoteSkip)
 	c.Assert(subscription.OnTerminationInvoice, qt.Equals, OnTerminationInvoiceSkip)
@@ -576,5 +836,71 @@ func TestSubscriptionRequest_UpdateWithPaymentMethod(t *testing.T) {
 		c.Assert(subscription.PaymentMethod, qt.IsNotNil)
 		c.Assert(subscription.PaymentMethod.PaymentMethodType, qt.Equals, "card")
 		c.Assert(subscription.PaymentMethod.PaymentMethodID, qt.Equals, "pm_123456")
+	})
+}
+
+func TestSubscriptionRequest_GetList(t *testing.T) {
+	t.Run("When the server is not reachable", func(t *testing.T) {
+		c := qt.New(t)
+
+		client := New().SetBaseURL("http://localhost:88888").SetApiKey("test_api_key")
+		result, err := client.Subscription().GetList(context.Background(), SubscriptionListInput{})
+		c.Assert(result, qt.IsNil)
+		c.Assert(err.Error(), qt.Equals, `{"status":0,"error":"","code":"","err":"Get \"http://localhost:88888/api/v1/subscriptions\": dial tcp: address 88888: invalid port"}`)
+	})
+
+	t.Run("When no parameters are provided", func(t *testing.T) {
+		c := qt.New(t)
+
+		server := lt.NewMockServer(c).
+			MatchMethod("GET").
+			MatchPath("/api/v1/subscriptions").
+			MatchQuery("").
+			MockResponse(mockSubscriptionListResponse)
+		defer server.Close()
+
+		result, err := server.Client().Subscription().GetList(context.Background(), SubscriptionListInput{})
+		c.Assert(err == nil, qt.IsTrue)
+		c.Assert(result.Subscriptions, qt.HasLen, 1)
+		c.Assert(result.Meta.CurrentPage, qt.Equals, 1)
+		c.Assert(result.Meta.TotalCount, qt.Equals, 1)
+
+		firstSubscription := result.Subscriptions[0]
+		c.Assert(firstSubscription.ExternalID, qt.Equals, "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba")
+	})
+
+	t.Run("When all parameters are provided including search_term", func(t *testing.T) {
+		c := qt.New(t)
+
+		server := lt.NewMockServer(c).
+			MatchMethod("GET").
+			MatchPath("/api/v1/subscriptions").
+			MatchQuery("per_page=5" +
+				"&page=1" +
+				"&external_id=5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba" +
+				"&external_customer_id=CUSTOMER_1" +
+				"&plan_code=premium" +
+				"&status[]=active").
+			MockResponse(mockSubscriptionListResponse)
+		defer server.Close()
+
+		perPage := 5
+		page := 1
+
+		result, err := server.Client().Subscription().GetList(context.Background(), SubscriptionListInput{
+			PerPage:            &perPage,
+			Page:               &page,
+			ExternalID:         "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+			ExternalCustomerID: "CUSTOMER_1",
+			PlanCode:           "premium",
+			Status:             []SubscriptionStatus{SubscriptionStatusActive},
+		})
+		c.Assert(err == nil, qt.IsTrue)
+		c.Assert(result.Subscriptions, qt.HasLen, 1)
+		c.Assert(result.Meta.CurrentPage, qt.Equals, 1)
+		c.Assert(result.Meta.TotalCount, qt.Equals, 1)
+
+		firstSubscription := result.Subscriptions[0]
+		c.Assert(firstSubscription.ExternalID, qt.Equals, "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba")
 	})
 }


### PR DESCRIPTION
## Description

This PR adds support for the `external_id` filter to customer and subscription `GetList`. This is the part of:
- https://github.com/getlago/lago-api/pull/5703
- https://github.com/getlago/lago-api/pull/5697
