### PR TITLE
feat(multi-entity): expose billing_entity on subscription and wallet

### DIFF
--- a/customer_wallet.go
+++ b/customer_wallet.go
@@ -2,8 +2,9 @@ package lago
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
+
+	"github.com/google/go-querystring/query"
 )
 
 type CustomerWalletRequest struct {
@@ -39,20 +40,15 @@ func (cwr *CustomerWalletRequest) Get(ctx context.Context, customerExternalID st
 func (cwr *CustomerWalletRequest) GetList(ctx context.Context, customerExternalID string, walletListInput *WalletListInput) (*WalletResult, *Error) {
 	subPath := fmt.Sprintf("%s/%s/%s", "customers", customerExternalID, "wallets")
 
-	jsonQueryParams, err := json.Marshal(walletListInput)
+	urlValues, err := query.Values(walletListInput)
 	if err != nil {
 		return nil, &Error{Err: err}
 	}
 
-	queryParams := make(map[string]string)
-	if err = json.Unmarshal(jsonQueryParams, &queryParams); err != nil {
-		return nil, &Error{Err: err}
-	}
-
 	clientRequest := &ClientRequest{
-		Path:        subPath,
-		QueryParams: queryParams,
-		Result:      &WalletResult{},
+		Path:      subPath,
+		UrlValues: urlValues,
+		Result:    &WalletResult{},
 	}
 
 	result, clientErr := cwr.client.Get(ctx, clientRequest)

--- a/payment_request.go
+++ b/payment_request.go
@@ -2,10 +2,10 @@ package lago
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
+	"github.com/google/go-querystring/query"
 	"github.com/google/uuid"
 )
 
@@ -20,11 +20,12 @@ type PaymentRequestResult struct {
 }
 
 type PaymentRequestListInput struct {
-	PerPage *int `json:"per_page,omitempty,string"`
-	Page    *int `json:"page,omitempty,string"`
+	PerPage *int `url:"per_page,omitempty"`
+	Page    *int `url:"page,omitempty"`
 
-	ExternalCustomerID string `json:"external_customer_id,omitempty"`
-	PaymentStatus      string `json:"payment_status,omitempty"`
+	ExternalCustomerID string   `url:"external_customer_id,omitempty"`
+	PaymentStatus      string   `url:"payment_status,omitempty"`
+	BillingEntityCodes []string `url:"billing_entity_codes[],omitempty"`
 }
 
 type PaymentRequest struct {
@@ -76,20 +77,15 @@ func (adr *PaymentRequestRequest) Get(ctx context.Context, paymentRequestID uuid
 }
 
 func (ir *PaymentRequestRequest) GetList(ctx context.Context, paymentRequestListInput *PaymentRequestListInput) (*PaymentRequestResult, *Error) {
-	jsonQueryParams, err := json.Marshal(paymentRequestListInput)
+	urlValues, err := query.Values(paymentRequestListInput)
 	if err != nil {
 		return nil, &Error{Err: err}
 	}
 
-	queryParams := make(map[string]string)
-	if err = json.Unmarshal(jsonQueryParams, &queryParams); err != nil {
-		return nil, &Error{Err: err}
-	}
-
 	clientRequest := &ClientRequest{
-		Path:        "payment_requests",
-		QueryParams: queryParams,
-		Result:      &PaymentRequestResult{},
+		Path:      "payment_requests",
+		UrlValues: urlValues,
+		Result:    &PaymentRequestResult{},
 	}
 
 	result, clientErr := ir.client.Get(ctx, clientRequest)

--- a/subscription.go
+++ b/subscription.go
@@ -100,6 +100,7 @@ type SubscriptionInput struct {
 	PaymentMethod        *PaymentMethodInput        `json:"payment_method,omitempty"`
 	InvoiceCustomSection *InvoiceCustomSectionInput `json:"invoice_custom_section,omitempty"`
 	ConsolidateInvoice   *bool                      `json:"consolidate_invoice,omitempty"`
+	BillingEntityCode    string                     `json:"billing_entity_code,omitempty"`
 }
 
 type SubscriptionsInput struct {
@@ -121,6 +122,7 @@ type SubscriptionListInput struct {
 	PerPage            *int                 `url:"per_page,omitempty"`
 	Page               *int                 `url:"page,omitempty"`
 	Status             []SubscriptionStatus `url:"status[],omitempty"`
+	BillingEntityCodes []string             `url:"billing_entity_codes[],omitempty"`
 }
 
 type Subscription struct {
@@ -128,6 +130,7 @@ type Subscription struct {
 	LagoCustomerID     uuid.UUID `json:"lago_customer_id"`
 	ExternalCustomerID string    `json:"external_customer_id"`
 	ExternalID         string    `json:"external_id"`
+	BillingEntityCode  string    `json:"billing_entity_code,omitempty"`
 
 	PlanCode string `json:"plan_code"`
 

--- a/wallet.go
+++ b/wallet.go
@@ -2,10 +2,10 @@ package lago
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
+	"github.com/google/go-querystring/query"
 	"github.com/google/uuid"
 )
 
@@ -94,9 +94,10 @@ type WalletInput struct {
 }
 
 type WalletListInput struct {
-	PerPage            *int   `json:"per_page,omitempty,string"`
-	Page               *int   `json:"page,omitempty,string"`
-	ExternalCustomerID string `json:"external_customer_id,omitempty"`
+	PerPage            *int     `url:"per_page,omitempty"`
+	Page               *int     `url:"page,omitempty"`
+	ExternalCustomerID string   `url:"external_customer_id,omitempty"`
+	BillingEntityCodes []string `url:"billing_entity_codes[],omitempty"`
 }
 
 type WalletResult struct {
@@ -173,20 +174,15 @@ func (bmr *WalletRequest) Get(ctx context.Context, walletID string) (*Wallet, *E
 }
 
 func (bmr *WalletRequest) GetList(ctx context.Context, walletListInput *WalletListInput) (*WalletResult, *Error) {
-	jsonQueryParams, err := json.Marshal(walletListInput)
+	urlValues, err := query.Values(walletListInput)
 	if err != nil {
 		return nil, &Error{Err: err}
 	}
 
-	queryParams := make(map[string]string)
-	if err = json.Unmarshal(jsonQueryParams, &queryParams); err != nil {
-		return nil, &Error{Err: err}
-	}
-
 	clientRequest := &ClientRequest{
-		Path:        "wallets",
-		QueryParams: queryParams,
-		Result:      &WalletResult{},
+		Path:      "wallets",
+		UrlValues: urlValues,
+		Result:    &WalletResult{},
 	}
 
 	result, clientErr := bmr.client.Get(ctx, clientRequest)

--- a/wallet.go
+++ b/wallet.go
@@ -90,6 +90,7 @@ type WalletInput struct {
 	Metadata                         map[string]string               `json:"metadata,omitempty"`
 	PaymentMethod                    *PaymentMethodInput             `json:"payment_method,omitempty"`
 	InvoiceCustomSection             *InvoiceCustomSectionInput      `json:"invoice_custom_section,omitempty"`
+	BillingEntityCode                string                          `json:"billing_entity_code,omitempty"`
 }
 
 type WalletListInput struct {
@@ -132,6 +133,7 @@ type Wallet struct {
 	LastConsumedCreditAt             time.Time                          `json:"last_consumed_credit_at,omitempty"`
 	TerminatedAt                     time.Time                          `json:"terminated_at,omitempty"`
 	RecurringTransactionRules        []RecurringTransactionRuleResponse `json:"recurring_transaction_rules,omitempty"`
+	BillingEntityCode                string                             `json:"billing_entity_code,omitempty"`
 	OngoingBalanceCents              int                                `json:"ongoing_balance_cents,omitempty"`
 	OngoingUsageBalanceCents         int                                `json:"ongoing_usage_balance_cents,omitempty"`
 	CreditsOngoingBalance            string                             `json:"credits_ongoing_balance,omitempty"`


### PR DESCRIPTION
## Summary

Multi-entity additions to the Go client: callers can pin a subscription or wallet to a specific billing entity at create/update time, read back the resolved entity on the response, and filter the subscription/wallet/payment-request list endpoints by `billing_entity_codes[]`.

## IMPORTANT NOTES

`WalletListInput` and `PaymentRequestListInput` were switched from `json:` tags to `url:` tags, and their `GetList` methods now use `query.Values()` + `UrlValues` instead of `json.Marshal -> map[string]string`. The previous shape couldn't carry array parameters — `json.Unmarshal` errored out and the request was never sent — so the move was necessary to add `billing_entity_codes[]` and brings these endpoints in line with the pattern already used by subscription, invoice, and credit-note list endpoints. No public field names changed; only struct tags.


## Changes

- `SubscriptionInput.BillingEntityCode` — sent on `POST /subscriptions` and `PUT /subscriptions/:external_id`.
- `Subscription.BillingEntityCode` — read back on every subscription response.
- `SubscriptionListInput.BillingEntityCodes` — array filter on `GET /subscriptions`.
- `WalletInput.BillingEntityCode` — sent on `POST /wallets` and `POST /customers/:external_id/wallets` (both share `WalletInput`).
- `Wallet.BillingEntityCode` — read back on every wallet response.
- `WalletListInput.BillingEntityCodes` — array filter on `GET /wallets` and `GET /customers/:external_id/wallets`.
- `PaymentRequestListInput.BillingEntityCodes` — array filter on `GET /payment_requests`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `go test -count=1 ./...` (existing suite passes)
