### PR TITLE
feat(purchase-order): add purchase_order_number types

### DIFF
--- a/subscription.go
+++ b/subscription.go
@@ -142,6 +142,7 @@ type SubscriptionInput struct {
 	InvoiceCustomSection *InvoiceCustomSectionInput        `json:"invoice_custom_section,omitempty"`
 	ConsolidateInvoice   *bool                             `json:"consolidate_invoice,omitempty"`
 	BillingEntityCode    string                            `json:"billing_entity_code,omitempty"`
+	PurchaseOrderNumber  *string                           `json:"purchase_order_number,omitempty"`
 	ActivationRules      []SubscriptionActivationRuleInput `json:"activation_rules,omitempty"`
 }
 
@@ -190,6 +191,7 @@ type Subscription struct {
 	OnTerminationCreditNote OnTerminationCreditNote `json:"on_termination_credit_note,omitempty"`
 	OnTerminationInvoice    OnTerminationInvoice    `json:"on_termination_invoice,omitempty"`
 	ConsolidateInvoice      bool                    `json:"consolidate_invoice"`
+	PurchaseOrderNumber     *string                 `json:"purchase_order_number,omitempty"`
 
 	PreviousPlanCode  string `json:"previous_plan_code"`
 	NextPlanCode      string `json:"next_plan_code"`

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -37,6 +37,7 @@ var mockSubscriptionResponse = `{
     "on_termination_credit_note": "skip",
     "on_termination_invoice": "skip",
     "consolidate_invoice": true,
+    "purchase_order_number": "PO-123",
     "activated_at": "2022-08-08T00:00:00Z",
     "cancellation_reason": "payment_failed",
     "activation_rules": [
@@ -420,6 +421,7 @@ func TestSubscriptionRequest_CreateWithPaymentMethod(t *testing.T) {
 		c := qt.New(t)
 
 		consolidate := true
+		purchaseOrderNumber := "PO-123"
 
 		server := lt.NewMockServer(c).
 			MatchMethod("POST").
@@ -435,7 +437,8 @@ func TestSubscriptionRequest_CreateWithPaymentMethod(t *testing.T) {
 						"payment_method_type": "card",
 						"payment_method_id": "pm_123456"
 					},
-					"consolidate_invoice": true
+					"consolidate_invoice": true,
+					"purchase_order_number": "PO-123"
 				}
 			}`).
 			MockResponse(mockSubscriptionResponse)
@@ -451,7 +454,8 @@ func TestSubscriptionRequest_CreateWithPaymentMethod(t *testing.T) {
 				PaymentMethodType: "card",
 				PaymentMethodID:   "pm_123456",
 			},
-			ConsolidateInvoice: &consolidate,
+			ConsolidateInvoice:  &consolidate,
+			PurchaseOrderNumber: &purchaseOrderNumber,
 		})
 
 		c.Assert(err == nil, qt.IsTrue)
@@ -459,6 +463,7 @@ func TestSubscriptionRequest_CreateWithPaymentMethod(t *testing.T) {
 		c.Assert(subscription.PaymentMethod.PaymentMethodType, qt.Equals, "card")
 		c.Assert(subscription.PaymentMethod.PaymentMethodID, qt.Equals, "pm_123456")
 		c.Assert(subscription.ConsolidateInvoice, qt.IsTrue)
+		c.Assert(subscription.PurchaseOrderNumber, qt.DeepEquals, Ptr("PO-123"))
 		c.Assert(subscription.AppliedInvoiceCustomSections, qt.HasLen, 1)
 		c.Assert(subscription.AppliedInvoiceCustomSections[0].LagoId.String(), qt.Equals, "1a901a90-1a90-1a90-1a90-1a901a901a90")
 		c.Assert(subscription.AppliedInvoiceCustomSections[0].InvoiceCustomSectionId.String(), qt.Equals, "2b902b90-2b90-2b90-2b90-2b902b902b90")

--- a/wallet.go
+++ b/wallet.go
@@ -32,6 +32,7 @@ type RecurringTransactionRuleInput struct {
 	TransactionName                  string                      `json:"transaction_name,omitempty"`
 	IgnorePaidTopUpLimits            *bool                       `json:"ignore_paid_top_up_limits,omitempty"`
 	GrantsTargetTopUp                *bool                       `json:"grants_target_top_up,omitempty"`
+	PurchaseOrderNumber              *string                     `json:"purchase_order_number,omitempty"`
 	PaymentMethod                    *PaymentMethodInput         `json:"payment_method,omitempty"`
 	InvoiceCustomSection             *InvoiceCustomSectionInput  `json:"invoice_custom_section,omitempty"`
 }
@@ -54,6 +55,7 @@ type RecurringTransactionRuleResponse struct {
 	TransactionName                  string                        `json:"transaction_name,omitempty"`
 	IgnorePaidTopUpLimits            bool                          `json:"ignore_paid_top_up_limits"`
 	GrantsTargetTopUp                *bool                         `json:"grants_target_top_up,omitempty"`
+	PurchaseOrderNumber              *string                       `json:"purchase_order_number,omitempty"`
 	PaymentMethod                    *PaymentMethodInput           `json:"payment_method,omitempty"`
 	AppliedInvoiceCustomSections     []AppliedInvoiceCustomSection `json:"applied_invoice_custom_sections,omitempty"`
 }
@@ -93,6 +95,7 @@ type WalletInput struct {
 	PaymentMethod                    *PaymentMethodInput             `json:"payment_method,omitempty"`
 	InvoiceCustomSection             *InvoiceCustomSectionInput      `json:"invoice_custom_section,omitempty"`
 	BillingEntityCode                string                          `json:"billing_entity_code,omitempty"`
+	PurchaseOrderNumber              *string                         `json:"purchase_order_number,omitempty"`
 }
 
 type WalletListInput struct {
@@ -148,6 +151,7 @@ type Wallet struct {
 	Metadata                         map[string]string                  `json:"metadata,omitempty"`
 	PaymentMethod                    *PaymentMethodInput                `json:"payment_method,omitempty"`
 	AppliedInvoiceCustomSections     []AppliedInvoiceCustomSection      `json:"applied_invoice_custom_sections,omitempty"`
+	PurchaseOrderNumber              *string                            `json:"purchase_order_number,omitempty"`
 }
 
 func (c *Client) Wallet() *WalletRequest {

--- a/wallet_test.go
+++ b/wallet_test.go
@@ -30,6 +30,7 @@ var mockWalletResponse = `{
 		"balance_cents": 10000,
 		"paid_top_up_max_amount_cents": 1000,
 		"paid_top_up_min_amount_cents": 200,
+		"purchase_order_number": "PO-123",
 		"expiration_at": "2022-07-07T23:59:59Z",
 		"created_at": "2022-04-29T08:59:51Z",
 		"recurring_transaction_rules": [{
@@ -48,6 +49,7 @@ var mockWalletResponse = `{
 			"invoice_requires_successful_payment": false,
 			"transaction_metadata": [],
 			"transaction_name": "Recurring Transaction Rule",
+			"purchase_order_number": "PO-RULE-123",
 			"ignore_paid_top_up_limits": false,
 			"grants_target_top_up": true,
 			"payment_method": {
@@ -184,6 +186,9 @@ func TestWallet_Create(t *testing.T) {
 	t.Run("When the server returns a successful response", func(t *testing.T) {
 		c := qt.New(t)
 
+		purchaseOrderNumber := "PO-123"
+		rulePurchaseOrderNumber := "PO-RULE-123"
+
 		server := lt.NewMockServer(c).
 			MatchMethod("POST").
 			MatchPath("/api/v1/wallets").
@@ -200,6 +205,7 @@ func TestWallet_Create(t *testing.T) {
 					"expiration_at": "2022-07-07T23:59:59Z",
 					"paid_top_up_max_amount_cents": 1000,
 					"paid_top_up_min_amount_cents": 200,
+					"purchase_order_number": "PO-123",
 					"recurring_transaction_rules": [
 						{
 							"paid_credits": "105.00",
@@ -211,6 +217,7 @@ func TestWallet_Create(t *testing.T) {
 							"method": "fixed",
 							"expiration_at": "2026-12-31T23:59:59Z",
 							"transaction_name": "Recurring Transaction Rule",
+							"purchase_order_number": "PO-RULE-123",
 							"ignore_paid_top_up_limits": true,
 							"grants_target_top_up": true
 						}
@@ -236,6 +243,7 @@ func TestWallet_Create(t *testing.T) {
 			ExpirationAt:            Ptr(time.Date(2022, 7, 7, 23, 59, 59, 0, time.UTC)),
 			PaidTopUpMaxAmountCents: Ptr(int(1000)),
 			PaidTopUpMinAmountCents: Ptr(int(200)),
+			PurchaseOrderNumber:     &purchaseOrderNumber,
 			RecurringTransactionRules: []RecurringTransactionRuleInput{
 				{
 					PaidCredits:           "105.00",
@@ -249,6 +257,7 @@ func TestWallet_Create(t *testing.T) {
 					TransactionName:       "Recurring Transaction Rule",
 					IgnorePaidTopUpLimits: Ptr(true),
 					GrantsTargetTopUp:     Ptr(true),
+					PurchaseOrderNumber:   &rulePurchaseOrderNumber,
 				},
 			},
 			AppliesTo: AppliesTo{
@@ -272,12 +281,14 @@ func TestWallet_Create(t *testing.T) {
 		c.Assert(*result.PaidTopUpMaxAmountCents, qt.Equals, int(1000))
 		c.Assert(result.PaidTopUpMinAmountCents, qt.IsNotNil)
 		c.Assert(*result.PaidTopUpMinAmountCents, qt.Equals, int(200))
+		c.Assert(result.PurchaseOrderNumber, qt.DeepEquals, Ptr("PO-123"))
 		c.Assert(len(result.RecurringTransactionRules), qt.Equals, 1)
 		c.Assert(result.RecurringTransactionRules[0].Trigger, qt.Equals, "interval")
 		c.Assert(result.RecurringTransactionRules[0].Interval, qt.Equals, "monthly")
 		c.Assert(result.RecurringTransactionRules[0].TransactionName, qt.Equals, "Recurring Transaction Rule")
 		c.Assert(result.RecurringTransactionRules[0].IgnorePaidTopUpLimits, qt.Equals, false)
 		c.Assert(result.RecurringTransactionRules[0].GrantsTargetTopUp, qt.DeepEquals, Ptr(true))
+		c.Assert(result.RecurringTransactionRules[0].PurchaseOrderNumber, qt.DeepEquals, Ptr("PO-RULE-123"))
 		c.Assert(result.RecurringTransactionRules[0].ExpirationAt, qt.DeepEquals, Ptr(time.Date(2026, 12, 31, 23, 59, 59, 0, time.UTC)))
 		c.Assert(result.AppliesTo.FeeTypes, qt.DeepEquals, []string{"charge"})
 		c.Assert(result.AppliesTo.BillableMetricCodes, qt.DeepEquals, []string{"bm1"})

--- a/wallet_transaction.go
+++ b/wallet_transaction.go
@@ -64,6 +64,7 @@ type WalletTransactionInput struct {
 	InvoiceRequiresSuccessfulPayment bool                        `json:"invoice_requires_successful_payment,omitempty"`
 	Metadata                         []WalletTransactionMetadata `json:"metadata,omitempty"`
 	IgnorePaidTopUpLimits            bool                        `json:"ignore_paid_top_up_limits,omitempty"`
+	PurchaseOrderNumber              *string                     `json:"purchase_order_number,omitempty"`
 	PaymentMethod                    *PaymentMethodInput         `json:"payment_method,omitempty"`
 	InvoiceCustomSection             *InvoiceCustomSectionInput  `json:"invoice_custom_section,omitempty"`
 }
@@ -94,6 +95,7 @@ type WalletTransaction struct {
 	RemainingCreditAmount            *string                       `json:"remaining_credit_amount,omitempty"`
 	Priority                         int                           `json:"priority,omitempty"`
 	InvoiceRequiresSuccessfulPayment bool                          `json:"invoice_requires_successful_payment,omitempty"`
+	PurchaseOrderNumber              *string                       `json:"purchase_order_number,omitempty"`
 	CreatedAt                        time.Time                     `json:"created_at,omitempty"`
 	SettledAt                        time.Time                     `json:"settled_at,omitempty"`
 	FailedAt                         time.Time                     `json:"failed_at,omitempty"`

--- a/wallet_transaction_test.go
+++ b/wallet_transaction_test.go
@@ -37,6 +37,7 @@ var mockWalletTransactionListResponse = `{
 					"value": "test"
 				}],
 				"name": "Test Transaction",
+				"purchase_order_number": "PO-123",
 				"payment_method": {
 					"payment_method_type": "card",
 					"payment_method_id": "pm_wt_123"
@@ -76,6 +77,8 @@ func TestWalletTransactionRequest_Create(t *testing.T) {
 	t.Run("When sending all the parameters", func(t *testing.T) {
 		c := qt.New(t)
 
+		purchaseOrderNumber := "PO-123"
+
 		server := lt.NewMockServer(c).
 			MatchMethod("POST").
 			MatchPath("/api/v1/wallet_transactions").
@@ -86,6 +89,7 @@ func TestWalletTransactionRequest_Create(t *testing.T) {
 					"metadata":                            [{"key": "source", "value": "test"}],
 					"name":                                "Test Transaction",
 					"paid_credits":                        "50.00",
+					"purchase_order_number":               "PO-123",
 					"voided_credits":                      "0.00",
 					"wallet_id":                           "1a901a90-1a90-1a90-1a90-1a901a901a90"
 				}
@@ -100,6 +104,7 @@ func TestWalletTransactionRequest_Create(t *testing.T) {
 			GrantedCredits:                   "0.00",
 			VoidedCredits:                    "0.00",
 			InvoiceRequiresSuccessfulPayment: true,
+			PurchaseOrderNumber:              &purchaseOrderNumber,
 			Metadata: []WalletTransactionMetadata{
 				{Key: "source", Value: "test"},
 			},
@@ -123,6 +128,7 @@ func TestWalletTransactionRequest_Create(t *testing.T) {
 					RemainingCreditAmount:            Ptr("50.00"),
 					Priority:                         50,
 					InvoiceRequiresSuccessfulPayment: true,
+					PurchaseOrderNumber:              Ptr("PO-123"),
 					CreatedAt:                        time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC),
 					SettledAt:                        time.Date(2024, 6, 1, 12, 5, 0, 0, time.UTC),
 					FailedAt:                         time.Date(2024, 6, 1, 12, 10, 0, 0, time.UTC),


### PR DESCRIPTION
This commit introduces the purchase order number

- Subscriptions
- Wallets and Wallets Transactions