### PR TITLE
feat(invoices): add Delete for draft invoices

### DIFF
--- a/invoice.go
+++ b/invoice.go
@@ -29,6 +29,7 @@ const (
 	InvoiceStatusFailed    InvoiceStatus = "failed"
 	InvoiceStatusVoided    InvoiceStatus = "voided"
 	InvoiceStatusPending   InvoiceStatus = "pending"
+	InvoiceStatusDeleted   InvoiceStatus = "deleted"
 )
 
 const (
@@ -531,6 +532,27 @@ func (ir *InvoiceRequest) LoseDispute(ctx context.Context, invoiceID string) (*I
 	}
 
 	return nil, nil
+}
+
+func (ir *InvoiceRequest) Delete(ctx context.Context, invoiceID string) (*Invoice, *Error) {
+	subPath := fmt.Sprintf("%s/%s", "invoices", invoiceID)
+
+	clientRequest := &ClientRequest{
+		Path:   subPath,
+		Result: &InvoiceResult{},
+	}
+
+	result, err := ir.client.Delete(ctx, clientRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	invoiceResult, ok := result.(*InvoiceResult)
+	if !ok {
+		return nil, &ErrorTypeAssert
+	}
+
+	return invoiceResult.Invoice, nil
 }
 
 // We have Invoice as a possible return to be consitent with other endpoints, but no Invoice will be returned.

--- a/invoice_test.go
+++ b/invoice_test.go
@@ -314,6 +314,32 @@ func TestInvoiceRequest_GetList(t *testing.T) {
 	})
 }
 
+func TestInvoiceRequest_Delete(t *testing.T) {
+	t.Run("When the server is not reachable", func(t *testing.T) {
+		c := qt.New(t)
+
+		client := New().SetBaseURL("http://localhost:88888").SetApiKey("test_api_key")
+		result, err := client.Invoice().Delete(context.Background(), "1a901a90-1a90-1a90-1a90-1a901a901a90")
+		c.Assert(result, qt.IsNil)
+		c.Assert(err != nil, qt.IsTrue)
+	})
+
+	t.Run("With an invoiceID in the request", func(t *testing.T) {
+		c := qt.New(t)
+
+		server := lt.NewMockServer(c).
+			MatchMethod("DELETE").
+			MatchPath("/api/v1/invoices/1a901a90-1a90-1a90-1a90-1a901a901a90").
+			MockResponse(map[string]any{"invoice": mockInvoice})
+		defer server.Close()
+
+		result, err := server.Client().Invoice().Delete(context.Background(), "1a901a90-1a90-1a90-1a90-1a901a901a90")
+
+		c.Assert(err == nil, qt.IsTrue)
+		assertInvoiceResponse(c, result)
+	})
+}
+
 func TestInvoiceRequest_PaymentUrl(t *testing.T) {
 	t.Run("When the server is not reachable", func(t *testing.T) {
 		c := qt.New(t)


### PR DESCRIPTION
## Context

_Part of the "delete draft invoice" feature_

A new endpoint was added to delete a draft invoice (https://github.com/getlago/lago-api/pull/5968).

## Description

Adds support for deleting a draft invoice (`DELETE /invoices/:id`).

- New `Invoice().Delete(ctx, invoiceID)` method
- New `InvoiceStatusDeleted` status constant