### PR TITLE
fix: decode quoted decimal overdue balance amounts

### DIFF
--- a/overdue_balance.go
+++ b/overdue_balance.go
@@ -3,6 +3,9 @@ package lago
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"math/big"
+	"strconv"
 )
 
 type OverdueBalanceRequest struct {
@@ -24,6 +27,45 @@ type OverdueBalance struct {
 	Month          string   `json:"month,omitempty"`
 	AmountCents    int      `json:"amount_cents,omitempty"`
 	AmountCurrency Currency `json:"currency,omitempty"`
+}
+
+func (o *OverdueBalance) UnmarshalJSON(data []byte) error {
+	type overdueBalanceAlias OverdueBalance
+
+	decoded := struct {
+		AmountCents json.RawMessage `json:"amount_cents"`
+		*overdueBalanceAlias
+	}{
+		overdueBalanceAlias: (*overdueBalanceAlias)(o),
+	}
+
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+
+	if len(decoded.AmountCents) == 0 || string(decoded.AmountCents) == "null" {
+		return nil
+	}
+
+	amountCents := string(decoded.AmountCents)
+	if decoded.AmountCents[0] == '"' {
+		if err := json.Unmarshal(decoded.AmountCents, &amountCents); err != nil {
+			return err
+		}
+	}
+
+	rational, ok := new(big.Rat).SetString(amountCents)
+	if !ok || !rational.IsInt() {
+		return fmt.Errorf("amount_cents must be a whole number: %q", amountCents)
+	}
+
+	value, err := strconv.ParseInt(rational.Num().String(), 10, 0)
+	if err != nil {
+		return fmt.Errorf("invalid amount_cents %q: %w", amountCents, err)
+	}
+
+	o.AmountCents = int(value)
+	return nil
 }
 
 func (c *Client) OverdueBalance() *OverdueBalanceRequest {

--- a/overdue_balance_test.go
+++ b/overdue_balance_test.go
@@ -1,0 +1,74 @@
+package lago_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	. "github.com/getlago/lago-go-client"
+	lt "github.com/getlago/lago-go-client/testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestOverdueBalanceRequest_GetList(t *testing.T) {
+	c := qt.New(t)
+
+	server := lt.NewMockServer(c).
+		MatchMethod("GET").
+		MatchPath("/api/v1/analytics/overdue_balance").
+		MatchQuery(map[string]string{}).
+		MockResponse(`{
+			"overdue_balances": [{
+				"month": "2026-07-01T00:00:00.000Z",
+				"amount_cents": "500.0",
+				"currency": "USD",
+				"lago_invoice_ids": ["275e091b-2e7e-4d1e-ae12-646994c9f8d7"],
+				"billing_entity_id": "bbea5aa6-197b-4ff1-a983-1884aea618e9"
+			}]
+		}`)
+	defer server.Close()
+
+	result, err := server.Client().OverdueBalance().GetList(context.Background(), &OverdueBalanceListInput{})
+
+	c.Assert(err == nil, qt.IsTrue)
+	c.Assert(result.OverdueBalances, qt.HasLen, 1)
+	c.Assert(result.OverdueBalances[0].Month, qt.Equals, "2026-07-01T00:00:00.000Z")
+	c.Assert(result.OverdueBalances[0].AmountCents, qt.Equals, 500)
+	c.Assert(result.OverdueBalances[0].AmountCurrency, qt.Equals, USD)
+}
+
+func TestOverdueBalance_UnmarshalJSON(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		amountCents string
+		want        int
+		wantErr     bool
+	}{
+		{name: "integer", amountCents: "500", want: 500},
+		{name: "decimal", amountCents: "500.0", want: 500},
+		{name: "quoted integer", amountCents: `"500"`, want: 500},
+		{name: "quoted decimal", amountCents: `"500.0"`, want: 500},
+		{name: "fractional", amountCents: "500.5", wantErr: true},
+		{name: "quoted fractional", amountCents: `"500.5"`, wantErr: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var balance OverdueBalance
+			err := json.Unmarshal([]byte(`{"amount_cents":`+test.amountCents+`}`), &balance)
+
+			if test.wantErr {
+				if err == nil {
+					t.Fatal("expected an error")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatal(err)
+			}
+			if balance.AmountCents != test.want {
+				t.Fatalf("AmountCents = %d, want %d", balance.AmountCents, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The overdue-balance endpoint can return `amount_cents` as a quoted decimal such as `"500.0"`. The client currently models this field as an `int`, so `GetList` fails to decode the response.

This change keeps the public field type unchanged while decoding numeric and quoted values that represent whole cents:

- Supports `500`, `500.0`, `"500"`, and `"500.0"`.
- Rejects fractional values such as `500.5` instead of silently rounding monetary data.
- Preserves the other overdue-balance response fields during decoding.

## Tests

- Added an HTTP regression test using the response reported in this issue and exercising `OverdueBalance().GetList`.
- Added table-driven decoder coverage for supported and rejected values.
- Ran `go vet ./...`.
- Ran `go test ./...`.

Closes #355