### PR TITLE
feat(invoice): add WebURL to invoice struct

### DIFF
--- a/invoice.go
+++ b/invoice.go
@@ -231,6 +231,7 @@ type Invoice struct {
 	NetPaymentTerm                      int  `json:"net_payment_term,omitempty"`
 
 	FileURL       string                    `json:"file_url,omitempty"`
+	WebURL        string                    `json:"web_url,omitempty"`
 	Metadata      []InvoiceMetadataResponse `json:"metadata,omitempty"`
 	VersionNumber int                       `json:"version_number,omitempty"`
 

--- a/invoice_test.go
+++ b/invoice_test.go
@@ -38,6 +38,7 @@ var mockInvoice = map[string]any{
 	"version_number":                          3,
 	"self_billed":                             false,
 	"file_url":                                "https://getlago.com/invoice/file",
+	"web_url":                                 "https://app.getlago.com/acme/customer/1a901a90-1a90-1a90-1a90-1a901a901a90/invoice/2b012b01-2b01-2b01-2b01-2b012b012b01/overview",
 	"created_at":                              "2022-04-29T08:59:51Z",
 	"updated_at":                              "2022-04-29T08:59:51Z",
 	"customer": map[string]any{
@@ -201,6 +202,7 @@ func assertInvoiceResponse(c *qt.C, result *Invoice) {
 	c.Assert(result.ProgressiveBillingCreditAmountCents, qt.Equals, 0)
 	c.Assert(result.NetPaymentTerm, qt.Equals, 30)
 	c.Assert(result.FileURL, qt.Equals, "https://getlago.com/invoice/file")
+	c.Assert(result.WebURL, qt.Equals, "https://app.getlago.com/acme/customer/1a901a90-1a90-1a90-1a90-1a901a901a90/invoice/2b012b01-2b01-2b01-2b01-2b012b012b01/overview")
 	c.Assert(result.VersionNumber, qt.Equals, 3)
 
 	c.Assert(result.Metadata, qt.HasLen, 1)


### PR DESCRIPTION
## Context

The invoice API object exposes a web_url attribute linking to the invoice page in the Lago dashboard, next to file_url (the PDF).

## Description

Add WebURL to the Invoice struct, mapped to web_url, and cover it in the invoice test fixture and assertions. PaymentRequest reuses Invoice, so it picks the field up as well.