### PR TITLE
feat(order-forms): add order_form resource

### DIFF
--- a/order.go
+++ b/order.go
@@ -1,0 +1,176 @@
+package lago
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/go-querystring/query"
+	"github.com/google/uuid"
+)
+
+const OrdersEndpoint string = "orders"
+
+type OrderStatus string
+
+const (
+	OrderStatusCreated  OrderStatus = "created"
+	OrderStatusExecuted OrderStatus = "executed"
+	OrderStatusFailed   OrderStatus = "failed"
+)
+
+type OrderRequest struct {
+	client *Client
+}
+
+// A trace of what the execution produced. Every key is always present, whichever the
+// order type, so the ones that do not apply keep their empty value.
+type OrderExecutionRecord struct {
+	ExecutedAt    *time.Time         `json:"executed_at,omitempty"`
+	ExecutionMode OrderExecutionMode `json:"execution_mode,omitempty"`
+
+	InvoiceID                 *uuid.UUID  `json:"invoice_id,omitempty"`
+	SubscriptionIDs           []uuid.UUID `json:"subscription_ids,omitempty"`
+	TerminatedSubscriptionIDs []uuid.UUID `json:"terminated_subscription_ids,omitempty"`
+	AppliedCouponIDs          []uuid.UUID `json:"applied_coupon_ids,omitempty"`
+	WalletIDs                 []uuid.UUID `json:"wallet_ids,omitempty"`
+
+	Errors []string `json:"errors,omitempty"`
+}
+
+type Order struct {
+	LagoID        uuid.UUID          `json:"lago_id,omitempty"`
+	Number        string             `json:"number,omitempty"`
+	Status        OrderStatus        `json:"status,omitempty"`
+	OrderType     QuoteOrderType     `json:"order_type,omitempty"`
+	ExecutionMode OrderExecutionMode `json:"execution_mode,omitempty"`
+	Currency      Currency           `json:"currency,omitempty"`
+
+	ExecutedAt      *time.Time            `json:"executed_at,omitempty"`
+	ExecutionRecord *OrderExecutionRecord `json:"execution_record,omitempty"`
+
+	LagoOrganizationID uuid.UUID `json:"lago_organization_id,omitempty"`
+	LagoCustomerID     uuid.UUID `json:"lago_customer_id,omitempty"`
+	LagoOrderFormID    uuid.UUID `json:"lago_order_form_id,omitempty"`
+
+	CreatedAt time.Time `json:"created_at,omitempty"`
+	UpdatedAt time.Time `json:"updated_at,omitempty"`
+
+	// The billing items of the quote version the order comes from, as they stood when it
+	// was approved. Omitted from the webhook payloads, being a heavy blob.
+	BillingSnapshot *QuoteBillingItems `json:"billing_snapshot,omitempty"`
+}
+
+type OrderListInput struct {
+	PerPage *int `url:"per_page,omitempty"`
+	Page    *int `url:"page,omitempty"`
+
+	Status          []OrderStatus        `url:"status[],omitempty"`
+	OrderType       []QuoteOrderType     `url:"order_type[],omitempty"`
+	ExecutionMode   []OrderExecutionMode `url:"execution_mode[],omitempty"`
+	CustomerIDs     []uuid.UUID          `url:"customer_id[],omitempty"`
+	Number          []string             `url:"number[],omitempty"`
+	OrderFormNumber []string             `url:"order_form_number[],omitempty"`
+	QuoteNumber     []string             `url:"quote_number[],omitempty"`
+	OwnerIDs        []uuid.UUID          `url:"owner_id[],omitempty"`
+
+	SearchTerm string `url:"search_term,omitempty"`
+
+	ExecutedAtFrom string `url:"executed_at_from,omitempty"`
+	ExecutedAtTo   string `url:"executed_at_to,omitempty"`
+}
+
+type OrderExecuteInput struct {
+	ExecutionMode OrderExecutionMode `json:"execution_mode,omitempty"`
+}
+
+type OrderExecuteParams struct {
+	Order *OrderExecuteInput `json:"order"`
+}
+
+type OrderResult struct {
+	Order  *Order   `json:"order,omitempty"`
+	Orders []Order  `json:"orders,omitempty"`
+	Meta   Metadata `json:"meta,omitempty"`
+}
+
+func (c *Client) Order() *OrderRequest {
+	return &OrderRequest{
+		client: c,
+	}
+}
+
+func (or *OrderRequest) Get(ctx context.Context, orderID string) (*Order, *Error) {
+	subPath := fmt.Sprintf("%s/%s", OrdersEndpoint, orderID)
+	clientRequest := &ClientRequest{
+		Path:   subPath,
+		Result: &OrderResult{},
+	}
+
+	result, err := or.client.Get(ctx, clientRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	orderResult, ok := result.(*OrderResult)
+	if !ok {
+		return nil, &ErrorTypeAssert
+	}
+
+	return orderResult.Order, nil
+}
+
+func (or *OrderRequest) GetList(ctx context.Context, orderListInput *OrderListInput) (*OrderResult, *Error) {
+	urlValues, err := query.Values(orderListInput)
+	if err != nil {
+		return nil, &Error{Err: err}
+	}
+
+	clientRequest := &ClientRequest{
+		Path:      OrdersEndpoint,
+		UrlValues: urlValues,
+		Result:    &OrderResult{},
+	}
+
+	result, clientErr := or.client.Get(ctx, clientRequest)
+	if clientErr != nil {
+		return nil, clientErr
+	}
+
+	orderResult, ok := result.(*OrderResult)
+	if !ok {
+		return nil, &ErrorTypeAssert
+	}
+
+	return orderResult, nil
+}
+
+// Execute carries out an order on demand, without waiting for its execute_at schedule.
+// It runs synchronously and is idempotent: an order already executed is returned untouched.
+func (or *OrderRequest) Execute(ctx context.Context, orderID string, executeInput *OrderExecuteInput) (*Order, *Error) {
+	subPath := fmt.Sprintf("%s/%s/%s", OrdersEndpoint, orderID, "execute")
+	clientRequest := &ClientRequest{
+		Path:   subPath,
+		Result: &OrderResult{},
+	}
+
+	if executeInput != nil {
+		clientRequest.Body = &OrderExecuteParams{Order: executeInput}
+	}
+
+	result, err := or.client.Post(ctx, clientRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	if result == nil {
+		return nil, nil
+	}
+
+	orderResult, ok := result.(*OrderResult)
+	if !ok {
+		return nil, &ErrorTypeAssert
+	}
+
+	return orderResult.Order, nil
+}

--- a/order_form.go
+++ b/order_form.go
@@ -1,0 +1,191 @@
+package lago
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/go-querystring/query"
+	"github.com/google/uuid"
+)
+
+const OrderFormsEndpoint string = "order_forms"
+
+type OrderFormStatus string
+
+const (
+	OrderFormStatusGenerated OrderFormStatus = "generated"
+	OrderFormStatusSigned    OrderFormStatus = "signed"
+	OrderFormStatusExpired   OrderFormStatus = "expired"
+	OrderFormStatusVoided    OrderFormStatus = "voided"
+)
+
+type OrderFormVoidReason string
+
+const (
+	OrderFormVoidReasonManual  OrderFormVoidReason = "manual"
+	OrderFormVoidReasonExpired OrderFormVoidReason = "expired"
+	OrderFormVoidReasonInvalid OrderFormVoidReason = "invalid"
+)
+
+type OrderExecutionMode string
+
+const (
+	OrderExecutionModeExecuteInLago OrderExecutionMode = "execute_in_lago"
+	OrderExecutionModeOrderOnly     OrderExecutionMode = "order_only"
+)
+
+type OrderFormRequest struct {
+	client *Client
+}
+
+type OrderForm struct {
+	LagoID     uuid.UUID           `json:"lago_id,omitempty"`
+	Number     string              `json:"number,omitempty"`
+	Status     OrderFormStatus     `json:"status,omitempty"`
+	VoidReason OrderFormVoidReason `json:"void_reason,omitempty"`
+
+	ExpiresAt         *time.Time `json:"expires_at,omitempty"`
+	SignedAt          *time.Time `json:"signed_at,omitempty"`
+	VoidedAt          *time.Time `json:"voided_at,omitempty"`
+	SignedDocumentUrl string     `json:"signed_document_url,omitempty"`
+
+	LagoOrganizationID uuid.UUID `json:"lago_organization_id,omitempty"`
+	LagoCustomerID     uuid.UUID `json:"lago_customer_id,omitempty"`
+	LagoQuoteID        uuid.UUID `json:"lago_quote_id,omitempty"`
+	LagoQuoteVersionID uuid.UUID `json:"lago_quote_version_id,omitempty"`
+
+	CreatedAt time.Time `json:"created_at,omitempty"`
+	UpdatedAt time.Time `json:"updated_at,omitempty"`
+}
+
+type OrderFormListInput struct {
+	PerPage *int `url:"per_page,omitempty"`
+	Page    *int `url:"page,omitempty"`
+
+	Status      []OrderFormStatus `url:"status[],omitempty"`
+	CustomerIDs []uuid.UUID       `url:"customer_id[],omitempty"`
+	Number      []string          `url:"number[],omitempty"`
+	QuoteNumber []string          `url:"quote_number[],omitempty"`
+	OwnerIDs    []uuid.UUID       `url:"owner_id[],omitempty"`
+
+	SearchTerm string `url:"search_term,omitempty"`
+
+	CreatedAtFrom string `url:"created_at_from,omitempty"`
+	CreatedAtTo   string `url:"created_at_to,omitempty"`
+	ExpiresAtFrom string `url:"expires_at_from,omitempty"`
+	ExpiresAtTo   string `url:"expires_at_to,omitempty"`
+}
+
+// The signed document is sent as a base64 data URI (data:<content_type>;base64,<data>),
+// accepting application/pdf, image/jpeg and image/png up to 10 MB.
+type OrderFormMarkAsSignedInput struct {
+	SignedDocument string             `json:"signed_document,omitempty"`
+	ExecutionMode  OrderExecutionMode `json:"execution_mode,omitempty"`
+	ExecuteAt      *time.Time         `json:"execute_at,omitempty"`
+}
+
+type OrderFormMarkAsSignedParams struct {
+	OrderForm *OrderFormMarkAsSignedInput `json:"order_form"`
+}
+
+type OrderFormResult struct {
+	OrderForm  *OrderForm  `json:"order_form,omitempty"`
+	OrderForms []OrderForm `json:"order_forms,omitempty"`
+	Meta       Metadata    `json:"meta,omitempty"`
+}
+
+func (c *Client) OrderForm() *OrderFormRequest {
+	return &OrderFormRequest{
+		client: c,
+	}
+}
+
+func (ofr *OrderFormRequest) Get(ctx context.Context, orderFormID string) (*OrderForm, *Error) {
+	subPath := fmt.Sprintf("%s/%s", OrderFormsEndpoint, orderFormID)
+	clientRequest := &ClientRequest{
+		Path:   subPath,
+		Result: &OrderFormResult{},
+	}
+
+	result, err := ofr.client.Get(ctx, clientRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	orderFormResult, ok := result.(*OrderFormResult)
+	if !ok {
+		return nil, &ErrorTypeAssert
+	}
+
+	return orderFormResult.OrderForm, nil
+}
+
+func (ofr *OrderFormRequest) GetList(ctx context.Context, orderFormListInput *OrderFormListInput) (*OrderFormResult, *Error) {
+	urlValues, err := query.Values(orderFormListInput)
+	if err != nil {
+		return nil, &Error{Err: err}
+	}
+
+	clientRequest := &ClientRequest{
+		Path:      OrderFormsEndpoint,
+		UrlValues: urlValues,
+		Result:    &OrderFormResult{},
+	}
+
+	result, clientErr := ofr.client.Get(ctx, clientRequest)
+	if clientErr != nil {
+		return nil, clientErr
+	}
+
+	orderFormResult, ok := result.(*OrderFormResult)
+	if !ok {
+		return nil, &ErrorTypeAssert
+	}
+
+	return orderFormResult, nil
+}
+
+// MarkAsSigned records the customer's signature and creates the order carrying the deal out.
+func (ofr *OrderFormRequest) MarkAsSigned(ctx context.Context, orderFormID string, markAsSignedInput *OrderFormMarkAsSignedInput) (*OrderForm, *Error) {
+	subPath := fmt.Sprintf("%s/%s/%s", OrderFormsEndpoint, orderFormID, "mark_as_signed")
+	clientRequest := &ClientRequest{
+		Path:   subPath,
+		Result: &OrderFormResult{},
+	}
+
+	if markAsSignedInput != nil {
+		clientRequest.Body = &OrderFormMarkAsSignedParams{OrderForm: markAsSignedInput}
+	}
+
+	return ofr.postAndUnwrap(ctx, clientRequest)
+}
+
+// Void voids a generated order form, cascading to the quote version it was generated from.
+func (ofr *OrderFormRequest) Void(ctx context.Context, orderFormID string) (*OrderForm, *Error) {
+	subPath := fmt.Sprintf("%s/%s/%s", OrderFormsEndpoint, orderFormID, "void")
+	clientRequest := &ClientRequest{
+		Path:   subPath,
+		Result: &OrderFormResult{},
+	}
+
+	return ofr.postAndUnwrap(ctx, clientRequest)
+}
+
+func (ofr *OrderFormRequest) postAndUnwrap(ctx context.Context, clientRequest *ClientRequest) (*OrderForm, *Error) {
+	result, err := ofr.client.Post(ctx, clientRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	if result == nil {
+		return nil, nil
+	}
+
+	orderFormResult, ok := result.(*OrderFormResult)
+	if !ok {
+		return nil, &ErrorTypeAssert
+	}
+
+	return orderFormResult.OrderForm, nil
+}

--- a/order_form_test.go
+++ b/order_form_test.go
@@ -1,0 +1,238 @@
+package lago_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	. "github.com/getlago/lago-go-client"
+	lt "github.com/getlago/lago-go-client/testing"
+)
+
+const orderFormID = "aa11aa11-aa11-aa11-aa11-aa11aa11aa11"
+
+var OrderFormGetMockResponse = map[string]interface{}{
+	"order_form": map[string]interface{}{
+		"lago_id":               orderFormID,
+		"number":                "OF-2026-0001",
+		"status":                "generated",
+		"void_reason":           nil,
+		"expires_at":            "2026-06-30T23:59:59Z",
+		"signed_at":             nil,
+		"voided_at":             nil,
+		"signed_document_url":   nil,
+		"lago_organization_id":  "3c123c12-3c12-3c12-3c12-3c123c123c12",
+		"lago_customer_id":      "2b012b01-2b01-2b01-2b01-2b012b012b01",
+		"lago_quote_id":         "1a901a90-1a90-1a90-1a90-1a901a901a90",
+		"lago_quote_version_id": "4d234d23-4d23-4d23-4d23-4d234d234d23",
+		"created_at":            "2026-04-29T08:59:51Z",
+		"updated_at":            "2026-04-29T08:59:51Z",
+	},
+}
+
+var OrderFormSignedMockResponse = map[string]interface{}{
+	"order_form": map[string]interface{}{
+		"lago_id":               orderFormID,
+		"number":                "OF-2026-0001",
+		"status":                "signed",
+		"void_reason":           nil,
+		"expires_at":            "2026-06-30T23:59:59Z",
+		"signed_at":             "2026-05-02T10:15:00Z",
+		"voided_at":             nil,
+		"signed_document_url":   "https://api.getlago.com/rails/active_storage/blobs/redirect/eyJfcmFpbHMi/OF-2026-0001",
+		"lago_organization_id":  "3c123c12-3c12-3c12-3c12-3c123c123c12",
+		"lago_customer_id":      "2b012b01-2b01-2b01-2b01-2b012b012b01",
+		"lago_quote_id":         "1a901a90-1a90-1a90-1a90-1a901a901a90",
+		"lago_quote_version_id": "4d234d23-4d23-4d23-4d23-4d234d234d23",
+		"created_at":            "2026-04-29T08:59:51Z",
+		"updated_at":            "2026-05-02T10:15:00Z",
+	},
+}
+
+var OrderFormGetListMockResponse = map[string]interface{}{
+	"order_forms": []map[string]interface{}{
+		{
+			"lago_id":               orderFormID,
+			"number":                "OF-2026-0001",
+			"status":                "generated",
+			"void_reason":           nil,
+			"expires_at":            "2026-06-30T23:59:59Z",
+			"signed_at":             nil,
+			"voided_at":             nil,
+			"signed_document_url":   nil,
+			"lago_organization_id":  "3c123c12-3c12-3c12-3c12-3c123c123c12",
+			"lago_customer_id":      "2b012b01-2b01-2b01-2b01-2b012b012b01",
+			"lago_quote_id":         "1a901a90-1a90-1a90-1a90-1a901a901a90",
+			"lago_quote_version_id": "4d234d23-4d23-4d23-4d23-4d234d234d23",
+			"created_at":            "2026-04-29T08:59:51Z",
+			"updated_at":            "2026-04-29T08:59:51Z",
+		},
+		{
+			"lago_id":               "bb22bb22-bb22-bb22-bb22-bb22bb22bb22",
+			"number":                "OF-2026-0002",
+			"status":                "voided",
+			"void_reason":           "manual",
+			"expires_at":            nil,
+			"signed_at":             nil,
+			"voided_at":             "2026-05-01T09:00:00Z",
+			"signed_document_url":   nil,
+			"lago_organization_id":  "3c123c12-3c12-3c12-3c12-3c123c123c12",
+			"lago_customer_id":      "2b012b01-2b01-2b01-2b01-2b012b012b01",
+			"lago_quote_id":         "6f456f45-6f45-6f45-6f45-6f456f456f45",
+			"lago_quote_version_id": "9c789c78-9c78-9c78-9c78-9c789c789c78",
+			"created_at":            "2026-04-30T08:59:51Z",
+			"updated_at":            "2026-05-01T09:00:00Z",
+		},
+	},
+	"meta": map[string]interface{}{
+		"current_page": 1,
+		"next_page":    0,
+		"prev_page":    0,
+		"total_pages":  1,
+		"total_count":  2,
+	},
+}
+
+func TestOrderFormRequest_Get(t *testing.T) {
+	t.Run("When query for a specific order form", func(t *testing.T) {
+		c := qt.New(t)
+
+		server := lt.NewMockServer(c).
+			MatchMethod("GET").
+			MatchPath("/api/v1/order_forms/" + orderFormID).
+			MockResponse(OrderFormGetMockResponse)
+		defer server.Close()
+
+		result, err := server.Client().OrderForm().Get(context.Background(), orderFormID)
+
+		c.Assert(err == nil, qt.IsTrue)
+		c.Assert(result, qt.IsNotNil)
+		c.Assert(result.LagoID.String(), qt.Equals, orderFormID)
+		c.Assert(result.Number, qt.Equals, "OF-2026-0001")
+		c.Assert(result.Status, qt.Equals, OrderFormStatusGenerated)
+		c.Assert(string(result.VoidReason), qt.Equals, "")
+		c.Assert(result.ExpiresAt, qt.IsNotNil)
+		c.Assert(result.ExpiresAt.Format(time.RFC3339), qt.Equals, "2026-06-30T23:59:59Z")
+		c.Assert(result.SignedAt, qt.IsNil)
+		c.Assert(result.SignedDocumentUrl, qt.Equals, "")
+		c.Assert(result.LagoQuoteVersionID.String(), qt.Equals, "4d234d23-4d23-4d23-4d23-4d234d234d23")
+	})
+}
+
+func TestOrderFormRequest_GetList(t *testing.T) {
+	t.Run("When query for all order forms", func(t *testing.T) {
+		c := qt.New(t)
+
+		server := lt.NewMockServer(c).
+			MatchMethod("GET").
+			MatchPath("/api/v1/order_forms").
+			MockResponse(OrderFormGetListMockResponse)
+		defer server.Close()
+
+		result, err := server.Client().OrderForm().GetList(context.Background(), &OrderFormListInput{})
+
+		c.Assert(err == nil, qt.IsTrue)
+		c.Assert(result.OrderForms, qt.HasLen, 2)
+		c.Assert(result.OrderForms[0].Number, qt.Equals, "OF-2026-0001")
+		c.Assert(result.OrderForms[1].Status, qt.Equals, OrderFormStatusVoided)
+		c.Assert(result.OrderForms[1].VoidReason, qt.Equals, OrderFormVoidReasonManual)
+		c.Assert(result.OrderForms[1].ExpiresAt, qt.IsNil)
+		c.Assert(result.Meta.CurrentPage, qt.Equals, 1)
+	})
+
+	t.Run("When filtering order forms", func(t *testing.T) {
+		c := qt.New(t)
+
+		server := lt.NewMockServer(c).
+			MatchMethod("GET").
+			MatchPath("/api/v1/order_forms").
+			MatchQuery(map[string]interface{}{
+				"status[]":       []string{"generated", "signed"},
+				"number[]":       []string{"OF-2026-0001"},
+				"quote_number[]": []string{"QT-2026-0001"},
+				"search_term":    "OF-2026",
+				"expires_at_to":  "2026-12-31T23:59:59Z",
+			}).
+			MockResponse(OrderFormGetListMockResponse)
+		defer server.Close()
+
+		result, err := server.Client().OrderForm().GetList(context.Background(), &OrderFormListInput{
+			Status:      []OrderFormStatus{OrderFormStatusGenerated, OrderFormStatusSigned},
+			Number:      []string{"OF-2026-0001"},
+			QuoteNumber: []string{"QT-2026-0001"},
+			SearchTerm:  "OF-2026",
+			ExpiresAtTo: "2026-12-31T23:59:59Z",
+		})
+
+		c.Assert(err == nil, qt.IsTrue)
+		c.Assert(result.OrderForms, qt.HasLen, 2)
+	})
+}
+
+func TestOrderFormRequest_MarkAsSigned(t *testing.T) {
+	t.Run("When signing without a payload", func(t *testing.T) {
+		c := qt.New(t)
+
+		server := lt.NewMockServer(c).
+			MatchMethod("POST").
+			MatchPath("/api/v1/order_forms/" + orderFormID + "/mark_as_signed").
+			MockResponse(OrderFormSignedMockResponse)
+		defer server.Close()
+
+		result, err := server.Client().OrderForm().MarkAsSigned(context.Background(), orderFormID, nil)
+
+		c.Assert(err == nil, qt.IsTrue)
+		c.Assert(result, qt.IsNotNil)
+		c.Assert(result.Status, qt.Equals, OrderFormStatusSigned)
+	})
+
+	t.Run("When signing with an execution mode and date", func(t *testing.T) {
+		c := qt.New(t)
+
+		executeAt, parseErr := time.Parse(time.RFC3339, "2026-07-01T00:00:00Z")
+		c.Assert(parseErr, qt.IsNil)
+
+		server := lt.NewMockServer(c).
+			MatchMethod("POST").
+			MatchPath("/api/v1/order_forms/" + orderFormID + "/mark_as_signed").
+			MatchJSONBody(map[string]interface{}{
+				"order_form": map[string]interface{}{
+					"signed_document": "data:application/pdf;base64,JVBERi0xLjQKJcfs",
+					"execution_mode":  "execute_in_lago",
+					"execute_at":      "2026-07-01T00:00:00Z",
+				},
+			}).
+			MockResponse(OrderFormSignedMockResponse)
+		defer server.Close()
+
+		result, err := server.Client().OrderForm().MarkAsSigned(context.Background(), orderFormID, &OrderFormMarkAsSignedInput{
+			SignedDocument: "data:application/pdf;base64,JVBERi0xLjQKJcfs",
+			ExecutionMode:  OrderExecutionModeExecuteInLago,
+			ExecuteAt:      &executeAt,
+		})
+
+		c.Assert(err == nil, qt.IsTrue)
+		c.Assert(result, qt.IsNotNil)
+		c.Assert(result.SignedAt, qt.IsNotNil)
+		c.Assert(result.SignedDocumentUrl, qt.Contains, "OF-2026-0001")
+	})
+}
+
+func TestOrderFormRequest_Void(t *testing.T) {
+	t.Run("When voiding a generated order form", func(t *testing.T) {
+		c := qt.New(t)
+
+		server := lt.NewMockServer(c).
+			MatchMethod("POST").
+			MatchPath("/api/v1/order_forms/" + orderFormID + "/void").
+			MockResponse(OrderFormGetMockResponse)
+		defer server.Close()
+
+		result, err := server.Client().OrderForm().Void(context.Background(), orderFormID)
+
+		c.Assert(err == nil, qt.IsTrue)
+		c.Assert(result, qt.IsNotNil)
+		c.Assert(result.LagoID.String(), qt.Equals, orderFormID)
+	})
+}

--- a/order_test.go
+++ b/order_test.go
@@ -1,0 +1,273 @@
+package lago_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	. "github.com/getlago/lago-go-client"
+	lt "github.com/getlago/lago-go-client/testing"
+)
+
+const orderID = "cc33cc33-cc33-cc33-cc33-cc33cc33cc33"
+
+var orderBillingSnapshotMock = map[string]interface{}{
+	"plans": []map[string]interface{}{
+		{
+			"id":      "7a567a56-7a56-7a56-7a56-7a567a567a56",
+			"localId": "b5c1e2a4-4e1e-4a7f-9f0e-9c1a0c7e1f2b",
+			"type":    "plan",
+			"payload": map[string]interface{}{"code": "premium_plan"},
+		},
+	},
+}
+
+var OrderGetMockResponse = map[string]interface{}{
+	"order": map[string]interface{}{
+		"lago_id":        orderID,
+		"number":         "OR-2026-0001",
+		"status":         "created",
+		"order_type":     "subscription_creation",
+		"execution_mode": "execute_in_lago",
+		"currency":       "EUR",
+		"executed_at":    nil,
+		"execution_record": map[string]interface{}{
+			"executed_at":                 nil,
+			"execution_mode":              "execute_in_lago",
+			"invoice_id":                  nil,
+			"subscription_ids":            []string{},
+			"terminated_subscription_ids": []string{},
+			"applied_coupon_ids":          []string{},
+			"wallet_ids":                  []string{},
+			"errors":                      []string{},
+		},
+		"lago_organization_id": "3c123c12-3c12-3c12-3c12-3c123c123c12",
+		"lago_customer_id":     "2b012b01-2b01-2b01-2b01-2b012b012b01",
+		"lago_order_form_id":   "aa11aa11-aa11-aa11-aa11-aa11aa11aa11",
+		"created_at":           "2026-05-02T10:15:00Z",
+		"updated_at":           "2026-05-02T10:15:00Z",
+		"billing_snapshot":     orderBillingSnapshotMock,
+	},
+}
+
+var OrderExecutedMockResponse = map[string]interface{}{
+	"order": map[string]interface{}{
+		"lago_id":        orderID,
+		"number":         "OR-2026-0001",
+		"status":         "executed",
+		"order_type":     "subscription_creation",
+		"execution_mode": "execute_in_lago",
+		"currency":       "EUR",
+		"executed_at":    "2026-07-01T00:00:00Z",
+		"execution_record": map[string]interface{}{
+			"executed_at":                 "2026-07-01T00:00:00Z",
+			"execution_mode":              "execute_in_lago",
+			"invoice_id":                  nil,
+			"subscription_ids":            []string{"dd44dd44-dd44-dd44-dd44-dd44dd44dd44"},
+			"terminated_subscription_ids": []string{},
+			"applied_coupon_ids":          []string{"ee55ee55-ee55-ee55-ee55-ee55ee55ee55"},
+			"wallet_ids":                  []string{},
+			"errors":                      []string{},
+		},
+		"lago_organization_id": "3c123c12-3c12-3c12-3c12-3c123c123c12",
+		"lago_customer_id":     "2b012b01-2b01-2b01-2b01-2b012b012b01",
+		"lago_order_form_id":   "aa11aa11-aa11-aa11-aa11-aa11aa11aa11",
+		"created_at":           "2026-05-02T10:15:00Z",
+		"updated_at":           "2026-07-01T00:00:00Z",
+		"billing_snapshot":     orderBillingSnapshotMock,
+	},
+}
+
+var OrderGetListMockResponse = map[string]interface{}{
+	"orders": []map[string]interface{}{
+		{
+			"lago_id":        orderID,
+			"number":         "OR-2026-0001",
+			"status":         "created",
+			"order_type":     "subscription_creation",
+			"execution_mode": "execute_in_lago",
+			"currency":       "EUR",
+			"executed_at":    nil,
+			"execution_record": map[string]interface{}{
+				"executed_at":                 nil,
+				"execution_mode":              "execute_in_lago",
+				"invoice_id":                  nil,
+				"subscription_ids":            []string{},
+				"terminated_subscription_ids": []string{},
+				"applied_coupon_ids":          []string{},
+				"wallet_ids":                  []string{},
+				"errors":                      []string{},
+			},
+			"lago_organization_id": "3c123c12-3c12-3c12-3c12-3c123c123c12",
+			"lago_customer_id":     "2b012b01-2b01-2b01-2b01-2b012b012b01",
+			"lago_order_form_id":   "aa11aa11-aa11-aa11-aa11-aa11aa11aa11",
+			"created_at":           "2026-05-02T10:15:00Z",
+			"updated_at":           "2026-05-02T10:15:00Z",
+			"billing_snapshot":     map[string]interface{}{},
+		},
+		{
+			"lago_id":        "ff66ff66-ff66-ff66-ff66-ff66ff66ff66",
+			"number":         "OR-2026-0002",
+			"status":         "failed",
+			"order_type":     "one_off",
+			"execution_mode": nil,
+			"currency":       "EUR",
+			"executed_at":    nil,
+			"execution_record": map[string]interface{}{
+				"executed_at":                 nil,
+				"execution_mode":              nil,
+				"invoice_id":                  nil,
+				"subscription_ids":            []string{},
+				"terminated_subscription_ids": []string{},
+				"applied_coupon_ids":          []string{},
+				"wallet_ids":                  []string{},
+				"errors":                      []string{"plan_not_found"},
+			},
+			"lago_organization_id": "3c123c12-3c12-3c12-3c12-3c123c123c12",
+			"lago_customer_id":     "2b012b01-2b01-2b01-2b01-2b012b012b01",
+			"lago_order_form_id":   "bb22bb22-bb22-bb22-bb22-bb22bb22bb22",
+			"created_at":           "2026-05-03T10:15:00Z",
+			"updated_at":           "2026-05-03T10:15:00Z",
+			"billing_snapshot":     map[string]interface{}{},
+		},
+	},
+	"meta": map[string]interface{}{
+		"current_page": 1,
+		"next_page":    0,
+		"prev_page":    0,
+		"total_pages":  1,
+		"total_count":  2,
+	},
+}
+
+func TestOrderRequest_Get(t *testing.T) {
+	t.Run("When query for a specific order", func(t *testing.T) {
+		c := qt.New(t)
+
+		server := lt.NewMockServer(c).
+			MatchMethod("GET").
+			MatchPath("/api/v1/orders/" + orderID).
+			MockResponse(OrderGetMockResponse)
+		defer server.Close()
+
+		result, err := server.Client().Order().Get(context.Background(), orderID)
+
+		c.Assert(err == nil, qt.IsTrue)
+		c.Assert(result, qt.IsNotNil)
+		c.Assert(result.LagoID.String(), qt.Equals, orderID)
+		c.Assert(result.Number, qt.Equals, "OR-2026-0001")
+		c.Assert(result.Status, qt.Equals, OrderStatusCreated)
+		c.Assert(result.OrderType, qt.Equals, QuoteOrderTypeSubscriptionCreation)
+		c.Assert(result.ExecutionMode, qt.Equals, OrderExecutionModeExecuteInLago)
+		c.Assert(result.Currency, qt.Equals, EUR)
+		c.Assert(result.ExecutedAt, qt.IsNil)
+		c.Assert(result.LagoOrderFormID.String(), qt.Equals, "aa11aa11-aa11-aa11-aa11-aa11aa11aa11")
+
+		c.Assert(result.ExecutionRecord, qt.IsNotNil)
+		c.Assert(result.ExecutionRecord.ExecutedAt, qt.IsNil)
+		c.Assert(result.ExecutionRecord.InvoiceID, qt.IsNil)
+		c.Assert(result.ExecutionRecord.Errors, qt.HasLen, 0)
+
+		c.Assert(result.BillingSnapshot, qt.IsNotNil)
+		c.Assert(result.BillingSnapshot.Plans, qt.HasLen, 1)
+		c.Assert(result.BillingSnapshot.Plans[0].Payload["code"], qt.Equals, "premium_plan")
+	})
+}
+
+func TestOrderRequest_GetList(t *testing.T) {
+	t.Run("When query for all orders", func(t *testing.T) {
+		c := qt.New(t)
+
+		server := lt.NewMockServer(c).
+			MatchMethod("GET").
+			MatchPath("/api/v1/orders").
+			MockResponse(OrderGetListMockResponse)
+		defer server.Close()
+
+		result, err := server.Client().Order().GetList(context.Background(), &OrderListInput{})
+
+		c.Assert(err == nil, qt.IsTrue)
+		c.Assert(result.Orders, qt.HasLen, 2)
+		c.Assert(result.Orders[0].Number, qt.Equals, "OR-2026-0001")
+		c.Assert(result.Orders[1].Status, qt.Equals, OrderStatusFailed)
+		c.Assert(string(result.Orders[1].ExecutionMode), qt.Equals, "")
+		c.Assert(result.Orders[1].ExecutionRecord.Errors, qt.DeepEquals, []string{"plan_not_found"})
+		c.Assert(result.Meta.CurrentPage, qt.Equals, 1)
+	})
+
+	t.Run("When filtering orders", func(t *testing.T) {
+		c := qt.New(t)
+
+		server := lt.NewMockServer(c).
+			MatchMethod("GET").
+			MatchPath("/api/v1/orders").
+			MatchQuery(map[string]interface{}{
+				"status[]":            []string{"created", "executed"},
+				"order_type[]":        []string{"one_off"},
+				"execution_mode[]":    []string{"execute_in_lago"},
+				"order_form_number[]": []string{"OF-2026-0001"},
+				"quote_number[]":      []string{"QT-2026-0001"},
+				"search_term":         "OR-2026",
+			}).
+			MockResponse(OrderGetListMockResponse)
+		defer server.Close()
+
+		result, err := server.Client().Order().GetList(context.Background(), &OrderListInput{
+			Status:          []OrderStatus{OrderStatusCreated, OrderStatusExecuted},
+			OrderType:       []QuoteOrderType{QuoteOrderTypeOneOff},
+			ExecutionMode:   []OrderExecutionMode{OrderExecutionModeExecuteInLago},
+			OrderFormNumber: []string{"OF-2026-0001"},
+			QuoteNumber:     []string{"QT-2026-0001"},
+			SearchTerm:      "OR-2026",
+		})
+
+		c.Assert(err == nil, qt.IsTrue)
+		c.Assert(result.Orders, qt.HasLen, 2)
+	})
+}
+
+func TestOrderRequest_Execute(t *testing.T) {
+	t.Run("When executing without a payload", func(t *testing.T) {
+		c := qt.New(t)
+
+		server := lt.NewMockServer(c).
+			MatchMethod("POST").
+			MatchPath("/api/v1/orders/" + orderID + "/execute").
+			MockResponse(OrderExecutedMockResponse)
+		defer server.Close()
+
+		result, err := server.Client().Order().Execute(context.Background(), orderID, nil)
+
+		c.Assert(err == nil, qt.IsTrue)
+		c.Assert(result, qt.IsNotNil)
+		c.Assert(result.Status, qt.Equals, OrderStatusExecuted)
+		c.Assert(result.ExecutedAt, qt.IsNotNil)
+		c.Assert(result.ExecutedAt.Format(time.RFC3339), qt.Equals, "2026-07-01T00:00:00Z")
+		c.Assert(result.ExecutionRecord.SubscriptionIDs, qt.HasLen, 1)
+		c.Assert(result.ExecutionRecord.SubscriptionIDs[0].String(), qt.Equals, "dd44dd44-dd44-dd44-dd44-dd44dd44dd44")
+		c.Assert(result.ExecutionRecord.AppliedCouponIDs, qt.HasLen, 1)
+		c.Assert(result.ExecutionRecord.TerminatedSubscriptionIDs, qt.HasLen, 0)
+	})
+
+	t.Run("When restating the execution mode", func(t *testing.T) {
+		c := qt.New(t)
+
+		server := lt.NewMockServer(c).
+			MatchMethod("POST").
+			MatchPath("/api/v1/orders/" + orderID + "/execute").
+			MatchJSONBody(map[string]interface{}{
+				"order": map[string]interface{}{"execution_mode": "execute_in_lago"},
+			}).
+			MockResponse(OrderExecutedMockResponse)
+		defer server.Close()
+
+		result, err := server.Client().Order().Execute(context.Background(), orderID, &OrderExecuteInput{
+			ExecutionMode: OrderExecutionModeExecuteInLago,
+		})
+
+		c.Assert(err == nil, qt.IsTrue)
+		c.Assert(result, qt.IsNotNil)
+		c.Assert(result.Status, qt.Equals, OrderStatusExecuted)
+	})
+}


### PR DESCRIPTION
Propagates the Order forms API ([lago-openapi#lago-1699](https://github.com/getlago/lago-openapi/tree/lago-1699)) to the Go client.

Stacked on #360 — based on `lago-1698`, so the diff here is order forms only. GitHub will retarget it to `main` once #360 merges.

Adds `client.OrderForm()` — `Get`, `GetList`, `MarkAsSigned`, `Void` — plus typed const sets for status, void reason and execution mode. The repeated-key list filters (`status[]`, `customer_id[]`, `number[]`, `quote_number[]`, `owner_id[]`) go through `query.Values` / `UrlValues`.

Note that `MarkAsSigned` wraps its payload under `order_form` (`OrderFormMarkAsSignedParams`), unlike the quote `Approve` body in #360, which is unwrapped. Both follow the spec.

`go build`, `go vet`, `go test ./...` and `gofmt -l .` are all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)