### PR TITLE
fix(client): tolerate empty JSON response bodies

### DIFF
--- a/alert_test.go
+++ b/alert_test.go
@@ -235,7 +235,7 @@ func TestAlertRequest_DeleteAll(t *testing.T) {
 		server := lt.NewMockServer(c).
 			MatchMethod("DELETE").
 			MatchPath("/api/v1/subscriptions/sub_1234/alerts").
-			MockResponse(nil)
+			MockEmptyResponse()
 		defer server.Close()
 
 		err := server.Client().Alert().DeleteAll(context.Background(), "sub_1234")
@@ -346,7 +346,7 @@ func TestAlertRequest_DeleteAllWithStatus(t *testing.T) {
 			MatchMethod("DELETE").
 			MatchPath("/api/v1/subscriptions/sub_1234/alerts").
 			MatchQuery(map[string]string{"subscription_status": "pending"}).
-			MockResponse(nil)
+			MockEmptyResponse()
 		defer server.Close()
 
 		err := server.Client().Alert().DeleteAll(context.Background(), "sub_1234", "pending")

--- a/credit_note_test.go
+++ b/credit_note_test.go
@@ -427,7 +427,7 @@ func TestCreditNoteRequest_Download(t *testing.T) {
 		assertCreditNoteResponse(c, result)
 	})
 
-	t.Run("When Download returns an empty response", func(t *testing.T) {
+	t.Run("When the file generation is enqueued and the body is empty", func(t *testing.T) {
 		c := qt.New(t)
 
 		creditNoteUUID, _ := uuid.Parse("1a901a90-1a90-1a90-1a90-1a901a901a90")
@@ -435,12 +435,12 @@ func TestCreditNoteRequest_Download(t *testing.T) {
 		server := lt.NewMockServer(c).
 			MatchMethod("POST").
 			MatchPath("/api/v1/credit_notes/1a901a90-1a90-1a90-1a90-1a901a901a90/download").
-			MockResponse(nil)
+			MockEmptyResponse()
 		defer server.Close()
 
 		result, err := server.Client().CreditNote().Download(context.Background(), creditNoteUUID)
 		c.Assert(err == nil, qt.IsTrue)
-		c.Assert(result == nil, qt.IsTrue)
+		c.Assert(result, qt.IsNil)
 	})
 }
 

--- a/invoice_test.go
+++ b/invoice_test.go
@@ -348,6 +348,37 @@ func TestInvoiceRequest_Download(t *testing.T) {
 		c.Assert(err == nil, qt.IsTrue)
 		c.Assert(result, qt.IsNil)
 	})
+
+	t.Run("When the file generation is enqueued and the body holds only whitespace", func(t *testing.T) {
+		c := qt.New(t)
+
+		server := lt.NewMockServer(c).
+			MatchMethod("POST").
+			MatchPath("/api/v1/invoices/1a901a90-1a90-1a90-1a90-1a901a901a90/download").
+			MockResponse("\n")
+		defer server.Close()
+
+		result, err := server.Client().Invoice().Download(context.Background(), "1a901a90-1a90-1a90-1a90-1a901a901a90")
+
+		c.Assert(err == nil, qt.IsTrue)
+		c.Assert(result, qt.IsNil)
+	})
+
+	t.Run("When the invoice is not found and the error body is empty", func(t *testing.T) {
+		c := qt.New(t)
+
+		server := lt.NewMockServer(c).
+			MatchMethod("POST").
+			MatchPath("/api/v1/invoices/1a901a90-1a90-1a90-1a90-1a901a901a90/download").
+			MockEmptyResponseWithCode(404)
+		defer server.Close()
+
+		result, err := server.Client().Invoice().Download(context.Background(), "1a901a90-1a90-1a90-1a90-1a901a901a90")
+
+		c.Assert(result, qt.IsNil)
+		c.Assert(err, qt.IsNotNil)
+		c.Assert(err.HTTPStatusCode, qt.Equals, 404)
+	})
 }
 
 func TestInvoiceRequest_Delete(t *testing.T) {

--- a/invoice_test.go
+++ b/invoice_test.go
@@ -318,6 +318,38 @@ func TestInvoiceRequest_GetList(t *testing.T) {
 	})
 }
 
+func TestInvoiceRequest_Download(t *testing.T) {
+	t.Run("When the file is already generated", func(t *testing.T) {
+		c := qt.New(t)
+
+		server := lt.NewMockServer(c).
+			MatchMethod("POST").
+			MatchPath("/api/v1/invoices/1a901a90-1a90-1a90-1a90-1a901a901a90/download").
+			MockResponse(map[string]any{"invoice": mockInvoice})
+		defer server.Close()
+
+		result, err := server.Client().Invoice().Download(context.Background(), "1a901a90-1a90-1a90-1a90-1a901a901a90")
+
+		c.Assert(err == nil, qt.IsTrue)
+		assertInvoiceResponse(c, result)
+	})
+
+	t.Run("When the file generation is enqueued and the body is empty", func(t *testing.T) {
+		c := qt.New(t)
+
+		server := lt.NewMockServer(c).
+			MatchMethod("POST").
+			MatchPath("/api/v1/invoices/1a901a90-1a90-1a90-1a90-1a901a901a90/download").
+			MockEmptyResponse()
+		defer server.Close()
+
+		result, err := server.Client().Invoice().Download(context.Background(), "1a901a90-1a90-1a90-1a90-1a901a901a90")
+
+		c.Assert(err == nil, qt.IsTrue)
+		c.Assert(result, qt.IsNil)
+	})
+}
+
 func TestInvoiceRequest_Delete(t *testing.T) {
 	t.Run("When the server is not reachable", func(t *testing.T) {
 		c := qt.New(t)
@@ -377,7 +409,7 @@ func TestInvoiceRequest_RetryPayment(t *testing.T) {
 		server := lt.NewMockServer(c).
 			MatchMethod("POST").
 			MatchPath("/api/v1/invoices/1a901a90-1a90-1a90-1a90-1a901a901a90/retry_payment").
-			MockResponse(nil)
+			MockEmptyResponse()
 		defer server.Close()
 
 		_, err := server.Client().Invoice().RetryPayment(context.Background(), "1a901a90-1a90-1a90-1a90-1a901a901a90")
@@ -396,7 +428,7 @@ func TestInvoiceRequest_RetryPayment(t *testing.T) {
 					"payment_method_id": "pm_123456"
 				}
 			}`).
-			MockResponse(nil)
+			MockEmptyResponse()
 		defer server.Close()
 
 		_, err := server.Client().Invoice().RetryPayment(context.Background(), "1a901a90-1a90-1a90-1a90-1a901a901a90", &PaymentMethodInput{

--- a/lago.go
+++ b/lago.go
@@ -2,6 +2,7 @@ package lago
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"time"
@@ -96,18 +97,34 @@ type Metadata struct {
 	TotalCount  int `json:"total_count,omitempty"`
 }
 
+// unmarshalJSON decodes a JSON response body into v, tolerating an empty body.
+//
+// Endpoints processing their work asynchronously answer 200 with an empty body
+// and an application/json content type. The default decoder rejects those with
+// "unexpected end of JSON input", so an empty body is treated as "nothing to
+// decode" and leaves v untouched.
+func unmarshalJSON(data []byte, v interface{}) error {
+	if len(data) == 0 {
+		return nil
+	}
+
+	return json.Unmarshal(data, v)
+}
+
 func New() *Client {
 	url := fmt.Sprintf("%s%s", baseURL, apiPath)
 
 	restyClient := resty.New().
 		SetBaseURL(url).
 		SetHeader("Content-Type", "application/json").
-		SetHeader("User-Agent", "lago-go-client github.com/getlago/lago-go-client/v1")
+		SetHeader("User-Agent", "lago-go-client github.com/getlago/lago-go-client/v1").
+		SetJSONUnmarshaler(unmarshalJSON)
 
 	ingestRestyClient := resty.New().
 		SetBaseURL(url).
 		SetHeader("Content-Type", "application/json").
-		SetHeader("User-Agent", "lago-go-client github.com/getlago/lago-go-client/v1")
+		SetHeader("User-Agent", "lago-go-client github.com/getlago/lago-go-client/v1").
+		SetJSONUnmarshaler(unmarshalJSON)
 
 	retryPolicy := DefaultRetryPolicy()
 
@@ -186,6 +203,12 @@ func (c *Client) handleErrorResponse(resp *resty.Response) *Error {
 	errObj, ok := resp.Error().(*Error)
 	if !ok {
 		return &ErrorTypeAssert
+	}
+
+	// An error response can come with an empty body, in which case nothing was
+	// decoded into errObj and the HTTP status is the only context available.
+	if errObj.HTTPStatusCode == 0 {
+		errObj.HTTPStatusCode = resp.StatusCode()
 	}
 
 	if resp.StatusCode() == 429 {

--- a/lago.go
+++ b/lago.go
@@ -1,6 +1,7 @@
 package lago
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -101,10 +102,12 @@ type Metadata struct {
 //
 // Endpoints processing their work asynchronously answer 200 with an empty body
 // and an application/json content type. The default decoder rejects those with
-// "unexpected end of JSON input", so an empty body is treated as "nothing to
-// decode" and leaves v untouched.
+// "unexpected end of JSON input", so a body holding nothing but whitespace is
+// treated as "nothing to decode" and leaves v untouched. Whitespace is trimmed
+// because servers and proxies in front of them may flush a trailing newline
+// rather than a strictly zero-length body.
 func unmarshalJSON(data []byte, v interface{}) error {
-	if len(data) == 0 {
+	if len(bytes.TrimSpace(data)) == 0 {
 		return nil
 	}
 

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -174,6 +174,10 @@ func (m *MockServer) MockEmptyResponse() *MockServer {
 	return m.MockResponse("")
 }
 
+func (m *MockServer) MockEmptyResponseWithCode(statusCode int) *MockServer {
+	return m.MockResponseWithCode(statusCode, "")
+}
+
 func (m *MockServer) MockResponseWithCode(statusCode int, mockResponse interface{}) *MockServer {
 	m.statusCode = statusCode
 	m.mockResponse = mockResponse

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -170,6 +170,10 @@ func (m *MockServer) MockResponse(mockResponse interface{}) *MockServer {
 	return m
 }
 
+func (m *MockServer) MockEmptyResponse() *MockServer {
+	return m.MockResponse("")
+}
+
 func (m *MockServer) MockResponseWithCode(statusCode int, mockResponse interface{}) *MockServer {
 	m.statusCode = statusCode
 	m.mockResponse = mockResponse


### PR DESCRIPTION
## Context

Endpoints that hand their work over to a background job answer `200` with an empty body and an `application/json` content type: `POST /invoices/:id/download`, `POST /credit_notes/:id/download` and `POST /invoices/:id/retry_payment` all do this when there is nothing to return yet.

The default JSON decoder rejects an empty body, so any of those calls failed with (even though the request succeeded server side.):
```json
{"status":0,"error":"","code":"","err":"unexpected end of JSON input"}
```
`RetryPayment` was fixed in #342 by dropping its `Result`, but `Download` still sets one — it does return an invoice or credit note once the file exists, so it kept failing on the first call and only succeeded once the file had been generated.

## Description

The client now installs a JSON unmarshaler that treats an empty body as "nothing to decode" instead of an error, which covers every verb and every endpoint at once rather than one call site at a time.

An error response with an empty body used to leave `HTTPStatusCode` at `0`. It is now filled in from the HTTP response, so the status is never lost when the body carries no details.

The `Download` tests previously mocked the empty response without a content type, which does not reach the decoder and hid the bug. `MockEmptyResponse` now reproduces what the API actually sends, and the tests fail without the fix.

closes #334

