### PR TITLE
fix(invoices,credit_notes,taxes): align with the API contract

### DIFF
--- a/credit_note.go
+++ b/credit_note.go
@@ -13,6 +13,7 @@ type CreditNoteCreditStatus string
 type CreditNoteRefundStatus string
 type CreditNoteReason string
 type CreditNoteErrorCode string
+type CreditNoteType string
 
 const (
 	CreditNoteCreditStatusAvailable CreditNoteCreditStatus = "available"
@@ -33,6 +34,12 @@ const (
 	CreditNoteReasonOrderCancellation     CreditNoteReason = "order_cancellation"
 	CreditNoteReasonFraudulentCharge      CreditNoteReason = "fraudulent_charge"
 	CreditNoteReasonOther                 CreditNoteReason = "other"
+)
+
+const (
+	CreditNoteTypeCredit CreditNoteType = "credit"
+	CreditNoteTypeRefund CreditNoteType = "refund"
+	CreditNoteTypeOffset CreditNoteType = "offset"
 )
 
 const (
@@ -76,7 +83,7 @@ type CreditNoteListInput struct {
 	AmountTo   int `url:"amount_to,omitempty,string"`
 
 	SearchTerm          string                 `url:"search_term,omitempty"`
-	BillingEntityIDs    []uuid.UUID            `url:"billing_entity_ids[],omitempty"`
+	BillingEntityCodes  []string               `url:"billing_entity_codes[],omitempty"`
 	CreditStatus        CreditNoteCreditStatus `url:"credit_status,omitempty"`
 	Currency            Currency               `url:"currency,omitempty"`
 	InvoiceNumber       string                 `url:"invoice_number,omitempty"`
@@ -84,6 +91,7 @@ type CreditNoteListInput struct {
 	Reason              CreditNoteReason       `url:"reason,omitempty"`
 	RefundStatus        CreditNoteRefundStatus `url:"refund_status,omitempty"`
 	SelfBilled          *bool                  `url:"self_billed,omitempty,string"`
+	Types               []CreditNoteType       `url:"types[],omitempty"`
 }
 
 type CreditNoteItem struct {

--- a/credit_note_test.go
+++ b/credit_note_test.go
@@ -478,30 +478,28 @@ func TestCreditNoteRequest_GetList(t *testing.T) {
 			MatchMethod("GET").
 			MatchPath("/api/v1/credit_notes").
 			MatchQuery(map[string]interface{}{
-				"per_page":              "10",
-				"page":                  "1",
-				"external_customer_id":  "CUSTOMER_1",
-				"issuing_date_from":     "2022-09-14T00:00:00Z",
-				"issuing_date_to":       "2022-09-14T23:59:59Z",
-				"amount_from":           "10",
-				"amount_to":             "1000",
-				"search_term":           "credit",
-				"billing_entity_ids[]":  []string{"1a901a90-1a90-1a90-1a90-1a901a901a90", "2a902a90-2a90-2a90-2a90-2a902a902a90"},
-				"credit_status":         "consumed",
-				"currency":              "EUR",
-				"invoice_number":        "LAG_1234",
-				"purchase_order_number": "PO-123",
-				"reason":                "order_change",
-				"refund_status":         "pending",
-				"self_billed":           "false",
+				"per_page":               "10",
+				"page":                   "1",
+				"external_customer_id":   "CUSTOMER_1",
+				"issuing_date_from":      "2022-09-14T00:00:00Z",
+				"issuing_date_to":        "2022-09-14T23:59:59Z",
+				"amount_from":            "10",
+				"amount_to":              "1000",
+				"search_term":            "credit",
+				"billing_entity_codes[]": []string{"acme_corp", "foo_bar"},
+				"types[]":                []string{"credit", "refund"},
+				"credit_status":          "consumed",
+				"currency":               "EUR",
+				"invoice_number":         "LAG_1234",
+				"purchase_order_number":  "PO-123",
+				"reason":                 "order_change",
+				"refund_status":          "pending",
+				"self_billed":            "false",
 			}).
 			MockResponse(mockCreditNoteListResponse)
 		defer server.Close()
 
 		selfBilled := false
-		entityUUID1, _ := uuid.Parse("1a901a90-1a90-1a90-1a90-1a901a901a90")
-		entityUUID2, _ := uuid.Parse("2a902a90-2a90-2a90-2a90-2a902a902a90")
-
 		result, err := server.Client().CreditNote().GetList(context.Background(), &CreditNoteListInput{
 			PerPage:             Ptr(10),
 			Page:                Ptr(1),
@@ -511,7 +509,8 @@ func TestCreditNoteRequest_GetList(t *testing.T) {
 			AmountFrom:          10,
 			AmountTo:            1000,
 			SearchTerm:          "credit",
-			BillingEntityIDs:    []uuid.UUID{entityUUID1, entityUUID2},
+			BillingEntityCodes:  []string{"acme_corp", "foo_bar"},
+			Types:               []CreditNoteType{CreditNoteTypeCredit, CreditNoteTypeRefund},
 			CreditStatus:        CreditNoteCreditStatusConsumed,
 			Currency:            EUR,
 			InvoiceNumber:       "LAG_1234",

--- a/invoice.go
+++ b/invoice.go
@@ -14,6 +14,7 @@ type InvoiceType string
 type InvoiceStatus string
 type InvoicePaymentStatus string
 type InvoiceCreditItemType string
+type InvoiceSettlementType string
 
 const (
 	SubscriptionInvoiceType       InvoiceType = "subscription"
@@ -21,6 +22,7 @@ const (
 	CreditInvoiceType             InvoiceType = "credit"
 	OneOffInvoiceType             InvoiceType = "one_off"
 	ProgressiveBillingInvoiceType InvoiceType = "progressive_billing"
+	AdvanceChargesInvoiceType     InvoiceType = "advance_charges"
 )
 
 const (
@@ -42,6 +44,11 @@ const (
 	InvoiceCreditItemCoupon     InvoiceCreditItemType = "coupon"
 	InvoiceCreditItemCreditNote InvoiceCreditItemType = "credit_note"
 	InvoiceCreditItemInvoice    InvoiceCreditItemType = "invoice"
+)
+
+const (
+	InvoiceSettlementPayment    InvoiceSettlementType = "payment"
+	InvoiceSettlementCreditNote InvoiceSettlementType = "credit_note"
 )
 
 type InvoiceRequest struct {
@@ -142,10 +149,11 @@ type InvoiceListInput struct {
 	AmountFrom *int `url:"amount_from,omitempty"`
 	AmountTo   *int `url:"amount_to,omitempty"`
 
-	SearchTerm          string      `url:"search_term,omitempty"`
-	BillingEntityIDs    []uuid.UUID `url:"billing_entity_ids[],omitempty"`
-	Currency            Currency    `url:"currency,omitempty"`
-	PurchaseOrderNumber string      `url:"purchase_order_number,omitempty"`
+	SearchTerm          string                  `url:"search_term,omitempty"`
+	BillingEntityCodes  []string                `url:"billing_entity_codes[],omitempty"`
+	Settlements         []InvoiceSettlementType `url:"settlements[],omitempty"`
+	Currency            Currency                `url:"currency,omitempty"`
+	PurchaseOrderNumber string                  `url:"purchase_order_number,omitempty"`
 
 	Metadata *InvoiceListInputMetadata `url:"metadata,omitempty"`
 }
@@ -208,11 +216,13 @@ type Invoice struct {
 	BillingEntityCode string    `json:"billing_entity_code,omitempty"`
 	Number            string    `json:"number,omitempty"`
 
-	PurchaseOrderNumber  *string   `json:"purchase_order_number,omitempty"`
-	IssuingDate          string    `json:"issuing_date,omitempty"`
-	PaymentDisputeLostAt time.Time `json:"payment_dispute_lost_at,omitempty"`
-	PaymentDueDate       string    `json:"payment_due_date,omitempty"`
-	PaymentOverdue       bool      `json:"payment_overdue,omitempty"`
+	PurchaseOrderNumber  *string    `json:"purchase_order_number,omitempty"`
+	IssuingDate          string     `json:"issuing_date,omitempty"`
+	PaymentDisputeLostAt time.Time  `json:"payment_dispute_lost_at,omitempty"`
+	PaymentDueDate       string     `json:"payment_due_date,omitempty"`
+	PaymentOverdue       bool       `json:"payment_overdue,omitempty"`
+	SelfBilled           bool       `json:"self_billed,omitempty"`
+	VoidedAt             *time.Time `json:"voided_at,omitempty"`
 
 	InvoiceType   InvoiceType          `json:"invoice_type,omitempty"`
 	Status        InvoiceStatus        `json:"status,omitempty"`
@@ -228,6 +238,8 @@ type Invoice struct {
 	SubTotalIncludingTaxesAmountCents   int  `json:"sub_total_including_taxes_amount_cents,omitempty"`
 	TotalAmountCents                    int  `json:"total_amount_cents,omitempty"`
 	TotalDueAmountCents                 int  `json:"total_due_amount_cents,omitempty"`
+	TotalPaidAmountCents                int  `json:"total_paid_amount_cents,omitempty"`
+	TotalOffsettedCreditNoteAmountCents int  `json:"total_offsetted_credit_note_amount_cents,omitempty"`
 	PrepaidCreditAmountCents            int  `json:"prepaid_credit_amount_cents,omitempty"`
 	PrepaidGrantedCreditAmountCents     *int `json:"prepaid_granted_credit_amount_cents,omitempty"`
 	PrepaidPurchasedCreditAmountCents   *int `json:"prepaid_purchased_credit_amount_cents,omitempty"`
@@ -235,6 +247,7 @@ type Invoice struct {
 	NetPaymentTerm                      int  `json:"net_payment_term,omitempty"`
 
 	FileURL       string                    `json:"file_url,omitempty"`
+	XMLURL        string                    `json:"xml_url,omitempty"`
 	WebURL        string                    `json:"web_url,omitempty"`
 	Metadata      []InvoiceMetadataResponse `json:"metadata,omitempty"`
 	VersionNumber int                       `json:"version_number,omitempty"`

--- a/invoice_test.go
+++ b/invoice_test.go
@@ -9,38 +9,42 @@ import (
 	lt "github.com/getlago/lago-go-client/testing"
 
 	qt "github.com/frankban/quicktest"
-	"github.com/google/uuid"
 )
 
 var mockInvoice = map[string]any{
-	"lago_id":                                 "1a901a90-1a90-1a90-1a90-1a901a901a90",
-	"billing_entity_code":                     "acme_corp",
-	"sequential_id":                           2,
-	"number":                                  "LAG-1234-001-002",
-	"issuing_date":                            "2022-04-30",
-	"payment_dispute_lost_at":                 "2022-09-14T16:35:31Z",
-	"payment_due_date":                        "2022-04-30",
-	"payment_overdue":                         true,
-	"net_payment_term":                        30,
-	"invoice_type":                            "subscription",
-	"status":                                  "finalized",
-	"payment_status":                          "succeeded",
-	"currency":                                "EUR",
-	"fees_amount_cents":                       100,
-	"coupons_amount_cents":                    10,
-	"credit_notes_amount_cents":               10,
-	"sub_total_excluding_taxes_amount_cents":  100,
-	"taxes_amount_cents":                      20,
-	"sub_total_including_taxes_amount_cents":  120,
-	"prepaid_credit_amount_cents":             0,
-	"progressive_billing_credit_amount_cents": 0,
-	"total_amount_cents":                      100,
-	"version_number":                          3,
-	"self_billed":                             false,
-	"file_url":                                "https://getlago.com/invoice/file",
-	"web_url":                                 "https://app.getlago.com/acme/customer/1a901a90-1a90-1a90-1a90-1a901a901a90/invoice/2b012b01-2b01-2b01-2b01-2b012b012b01/overview",
-	"created_at":                              "2022-04-29T08:59:51Z",
-	"updated_at":                              "2022-04-29T08:59:51Z",
+	"lago_id":                                  "1a901a90-1a90-1a90-1a90-1a901a901a90",
+	"billing_entity_code":                      "acme_corp",
+	"sequential_id":                            2,
+	"number":                                   "LAG-1234-001-002",
+	"issuing_date":                             "2022-04-30",
+	"payment_dispute_lost_at":                  "2022-09-14T16:35:31Z",
+	"payment_due_date":                         "2022-04-30",
+	"payment_overdue":                          true,
+	"net_payment_term":                         30,
+	"invoice_type":                             "subscription",
+	"status":                                   "finalized",
+	"payment_status":                           "succeeded",
+	"currency":                                 "EUR",
+	"fees_amount_cents":                        100,
+	"coupons_amount_cents":                     10,
+	"credit_notes_amount_cents":                10,
+	"sub_total_excluding_taxes_amount_cents":   100,
+	"taxes_amount_cents":                       20,
+	"sub_total_including_taxes_amount_cents":   120,
+	"prepaid_credit_amount_cents":              0,
+	"progressive_billing_credit_amount_cents":  0,
+	"total_amount_cents":                       100,
+	"total_due_amount_cents":                   40,
+	"total_paid_amount_cents":                  60,
+	"total_offsetted_credit_note_amount_cents": 10,
+	"version_number":                           3,
+	"self_billed":                              true,
+	"file_url":                                 "https://getlago.com/invoice/file",
+	"xml_url":                                  "https://getlago.com/invoice/file.xml",
+	"voided_at":                                "2022-09-14T16:35:31Z",
+	"web_url":                                  "https://app.getlago.com/acme/customer/1a901a90-1a90-1a90-1a90-1a901a901a90/invoice/2b012b01-2b01-2b01-2b01-2b012b012b01/overview",
+	"created_at":                               "2022-04-29T08:59:51Z",
+	"updated_at":                               "2022-04-29T08:59:51Z",
 	"customer": map[string]any{
 		"lago_id":                      "1a901a90-1a90-1a90-1a90-1a901a901a90",
 		"sequential_id":                1,
@@ -186,6 +190,8 @@ func assertInvoiceResponse(c *qt.C, result *Invoice) {
 	c.Assert(result.PaymentDisputeLostAt.Format(time.RFC3339), qt.Equals, "2022-09-14T16:35:31Z")
 	c.Assert(result.PaymentDueDate, qt.Equals, "2022-04-30")
 	c.Assert(result.PaymentOverdue, qt.Equals, true)
+	c.Assert(result.SelfBilled, qt.Equals, true)
+	c.Assert(result.VoidedAt.Format(time.RFC3339), qt.Equals, "2022-09-14T16:35:31Z")
 	c.Assert(result.InvoiceType, qt.Equals, InvoiceType("subscription"))
 	c.Assert(result.Status, qt.Equals, InvoiceStatus("finalized"))
 	c.Assert(result.PaymentStatus, qt.Equals, InvoicePaymentStatus("succeeded"))
@@ -197,11 +203,14 @@ func assertInvoiceResponse(c *qt.C, result *Invoice) {
 	c.Assert(result.SubTotalExcludingTaxesAmountCents, qt.Equals, 100)
 	c.Assert(result.SubTotalIncludingTaxesAmountCents, qt.Equals, 120)
 	c.Assert(result.TotalAmountCents, qt.Equals, 100)
-	c.Assert(result.TotalDueAmountCents, qt.Equals, 0)
+	c.Assert(result.TotalDueAmountCents, qt.Equals, 40)
+	c.Assert(result.TotalPaidAmountCents, qt.Equals, 60)
+	c.Assert(result.TotalOffsettedCreditNoteAmountCents, qt.Equals, 10)
 	c.Assert(result.PrepaidCreditAmountCents, qt.Equals, 0)
 	c.Assert(result.ProgressiveBillingCreditAmountCents, qt.Equals, 0)
 	c.Assert(result.NetPaymentTerm, qt.Equals, 30)
 	c.Assert(result.FileURL, qt.Equals, "https://getlago.com/invoice/file")
+	c.Assert(result.XMLURL, qt.Equals, "https://getlago.com/invoice/file.xml")
 	c.Assert(result.WebURL, qt.Equals, "https://app.getlago.com/acme/customer/1a901a90-1a90-1a90-1a90-1a901a901a90/invoice/2b012b01-2b01-2b01-2b01-2b012b012b01/overview")
 	c.Assert(result.VersionNumber, qt.Equals, 3)
 
@@ -263,33 +272,30 @@ func TestInvoiceRequest_GetList(t *testing.T) {
 			MatchMethod("GET").
 			MatchPath("/api/v1/invoices").
 			MatchQuery(map[string]interface{}{
-				"per_page":              "10",
-				"page":                  "1",
-				"external_customer_id":  "CUSTOMER_1",
-				"invoice_type":          "subscription",
-				"status":                "finalized",
-				"payment_status":        "succeeded",
-				"issuing_date_from":     "2022-09-14T00:00:00Z",
-				"issuing_date_to":       "2022-09-14T23:59:59Z",
-				"amount_from":           "10",
-				"amount_to":             "1000",
-				"search_term":           "credit",
-				"billing_entity_ids[]":  []string{"1a901a90-1a90-1a90-1a90-1a901a901a90", "1a901a90-1a90-1a90-1a90-1a901a901a91"},
-				"currency":              "EUR",
-				"payment_overdue":       "true",
-				"partially_paid":        "true",
-				"self_billed":           "false",
-				"payment_dispute_lost":  "true",
-				"metadata[key1]":        "10",
-				"metadata[key2]":        "value2",
-				"purchase_order_number": "PO-123",
+				"per_page":               "10",
+				"page":                   "1",
+				"external_customer_id":   "CUSTOMER_1",
+				"invoice_type":           "subscription",
+				"status":                 "finalized",
+				"payment_status":         "succeeded",
+				"issuing_date_from":      "2022-09-14T00:00:00Z",
+				"issuing_date_to":        "2022-09-14T23:59:59Z",
+				"amount_from":            "10",
+				"amount_to":              "1000",
+				"search_term":            "credit",
+				"billing_entity_codes[]": []string{"acme_corp", "foo_bar"},
+				"settlements[]":          []string{"payment", "credit_note"},
+				"currency":               "EUR",
+				"payment_overdue":        "true",
+				"partially_paid":         "true",
+				"self_billed":            "false",
+				"payment_dispute_lost":   "true",
+				"metadata[key1]":         "10",
+				"metadata[key2]":         "value2",
+				"purchase_order_number":  "PO-123",
 			}).
 			MockResponse(mockInvoiceListResponse)
 		defer server.Close()
-
-		// selfBilled := false
-		entityUUID, _ := uuid.Parse("1a901a90-1a90-1a90-1a90-1a901a901a90")
-		entityUUID2, _ := uuid.Parse("1a901a90-1a90-1a90-1a90-1a901a901a91")
 
 		result, err := server.Client().Invoice().GetList(context.Background(), &InvoiceListInput{
 			PerPage:             Ptr(10),
@@ -303,7 +309,8 @@ func TestInvoiceRequest_GetList(t *testing.T) {
 			AmountFrom:          Ptr(10),
 			AmountTo:            Ptr(1000),
 			SearchTerm:          "credit",
-			BillingEntityIDs:    []uuid.UUID{entityUUID, entityUUID2},
+			BillingEntityCodes:  []string{"acme_corp", "foo_bar"},
+			Settlements:         []InvoiceSettlementType{InvoiceSettlementPayment, InvoiceSettlementCreditNote},
 			Currency:            EUR,
 			PaymentOverdue:      Ptr(true),
 			PartiallyPaid:       Ptr(true),

--- a/tax.go
+++ b/tax.go
@@ -39,13 +39,14 @@ type TaxResult struct {
 }
 
 type Tax struct {
-	LagoID                uuid.UUID `json:"lago_id,omitempty"`
-	Name                  string    `json:"name,omitempty"`
-	Code                  string    `json:"code,omitempty"`
-	Rate                  float32   `json:"rate,omitempty"`
-	Description           string    `json:"description,omitempty"`
-	AppliedToOrganization bool      `json:"applied_to_organization,omitempty"`
-	CreatedAt             time.Time `json:"created_at,omitempty"`
+	LagoID                        uuid.UUID `json:"lago_id,omitempty"`
+	Name                          string    `json:"name,omitempty"`
+	Code                          string    `json:"code,omitempty"`
+	Rate                          float32   `json:"rate,omitempty"`
+	Description                   string    `json:"description,omitempty"`
+	AppliedToOrganization         bool      `json:"applied_to_organization,omitempty"`
+	AppliedToBillingEntitiesCodes []string  `json:"applied_to_billing_entities_codes,omitempty"`
+	CreatedAt                     time.Time `json:"created_at,omitempty"`
 }
 
 func (c *Client) Tax() *TaxRequest {


### PR DESCRIPTION
The billing_entity_ids[] filter on invoices and credit notes never applied: both controllers read billing_entity_codes. Add the invoice response fields the serializer always emits (total_paid_amount_cents, total_offsetted_credit_note_amount_cents, xml_url, voided_at, self_billed), the tax applied_to_billing_entities_codes field, the advance_charges invoice type, and the new settlements[] and types[] filters.