### PR TITLE
feat(payments): support list filters

### DIFF
--- a/customer.go
+++ b/customer.go
@@ -422,7 +422,6 @@ type CustomerPaymentListInput struct {
 	CreatedAtFrom       string   `url:"created_at_from,omitempty"`
 	CreatedAtTo         string   `url:"created_at_to,omitempty"`
 	PaymentProviderType []string `url:"payment_provider_type[],omitempty"`
-	PaymentMethodType   []string `url:"payment_method_type[],omitempty"`
 	Currency            Currency `url:"currency,omitempty"`
 	InvoiceNumber       string   `url:"invoice_number,omitempty"`
 	PaymentType         []string `url:"payment_type[],omitempty"`

--- a/customer.go
+++ b/customer.go
@@ -413,7 +413,21 @@ type CustomerPaymentListInput struct {
 	PerPage *int `url:"per_page,omitempty,string"`
 	Page    *int `url:"page,omitempty,string"`
 
-	InvoiceID string `url:"invoice_id,omitempty"`
+	InvoiceID           string   `url:"invoice_id,omitempty"`
+	PaymentStatus       []string `url:"payment_status[],omitempty"`
+	PaymentStatuses     []string `url:"payment_statuses[],omitempty"`
+	AmountFrom          *int64   `url:"amount_from,omitempty"`
+	AmountTo            *int64   `url:"amount_to,omitempty"`
+	ReceiptNumber       string   `url:"receipt_number,omitempty"`
+	CreatedAtFrom       string   `url:"created_at_from,omitempty"`
+	CreatedAtTo         string   `url:"created_at_to,omitempty"`
+	PaymentProviderType []string `url:"payment_provider_type[],omitempty"`
+	PaymentMethodType   []string `url:"payment_method_type[],omitempty"`
+	Currency            Currency `url:"currency,omitempty"`
+	InvoiceNumber       string   `url:"invoice_number,omitempty"`
+	PaymentType         []string `url:"payment_type[],omitempty"`
+	PayableType         []string `url:"payable_type[],omitempty"`
+	SearchTerm          string   `url:"search_term,omitempty"`
 }
 
 type CustomerPaymentRequestListInput struct {

--- a/payment.go
+++ b/payment.go
@@ -33,7 +33,6 @@ type PaymentListInput struct {
 	CreatedAtFrom       string   `json:"created_at_from,omitempty" url:"created_at_from,omitempty"`
 	CreatedAtTo         string   `json:"created_at_to,omitempty" url:"created_at_to,omitempty"`
 	PaymentProviderType []string `json:"payment_provider_type,omitempty" url:"payment_provider_type[],omitempty"`
-	PaymentMethodType   []string `json:"payment_method_type,omitempty" url:"payment_method_type[],omitempty"`
 	Currency            Currency `json:"currency,omitempty" url:"currency,omitempty"`
 	InvoiceNumber       string   `json:"invoice_number,omitempty" url:"invoice_number,omitempty"`
 	PaymentType         []string `json:"payment_type,omitempty" url:"payment_type[],omitempty"`

--- a/payment.go
+++ b/payment.go
@@ -2,10 +2,10 @@ package lago
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
+	"github.com/google/go-querystring/query"
 	"github.com/google/uuid"
 )
 
@@ -20,11 +20,25 @@ type PaymentResult struct {
 }
 
 type PaymentListInput struct {
-	PerPage *int `json:"per_page,omitempty,string"`
-	Page    *int `json:"page,omitempty,string"`
+	PerPage *int `json:"per_page,omitempty,string" url:"per_page,omitempty"`
+	Page    *int `json:"page,omitempty,string" url:"page,omitempty"`
 
-	ExternalCustomerID string `json:"external_customer_id,omitempty"`
-	InvoiceID          string `json:"invoice_id,omitempty"`
+	ExternalCustomerID  string   `json:"external_customer_id,omitempty" url:"external_customer_id,omitempty"`
+	InvoiceID           string   `json:"invoice_id,omitempty" url:"invoice_id,omitempty"`
+	PaymentStatus       []string `json:"payment_status,omitempty" url:"payment_status[],omitempty"`
+	PaymentStatuses     []string `json:"payment_statuses,omitempty" url:"payment_statuses[],omitempty"`
+	AmountFrom          *int64   `json:"amount_from,omitempty" url:"amount_from,omitempty"`
+	AmountTo            *int64   `json:"amount_to,omitempty" url:"amount_to,omitempty"`
+	ReceiptNumber       string   `json:"receipt_number,omitempty" url:"receipt_number,omitempty"`
+	CreatedAtFrom       string   `json:"created_at_from,omitempty" url:"created_at_from,omitempty"`
+	CreatedAtTo         string   `json:"created_at_to,omitempty" url:"created_at_to,omitempty"`
+	PaymentProviderType []string `json:"payment_provider_type,omitempty" url:"payment_provider_type[],omitempty"`
+	PaymentMethodType   []string `json:"payment_method_type,omitempty" url:"payment_method_type[],omitempty"`
+	Currency            Currency `json:"currency,omitempty" url:"currency,omitempty"`
+	InvoiceNumber       string   `json:"invoice_number,omitempty" url:"invoice_number,omitempty"`
+	PaymentType         []string `json:"payment_type,omitempty" url:"payment_type[],omitempty"`
+	PayableType         []string `json:"payable_type,omitempty" url:"payable_type[],omitempty"`
+	SearchTerm          string   `json:"search_term,omitempty" url:"search_term,omitempty"`
 }
 
 type NextAction struct {
@@ -90,20 +104,15 @@ func (adr *ManualPaymentRequest) Get(ctx context.Context, paymentID string) (*Pa
 }
 
 func (ir *ManualPaymentRequest) GetList(ctx context.Context, paymentListInput *PaymentListInput) (*PaymentResult, *Error) {
-	jsonQueryParams, err := json.Marshal(paymentListInput)
+	urlValues, err := query.Values(paymentListInput)
 	if err != nil {
 		return nil, &Error{Err: err}
 	}
 
-	queryParams := make(map[string]string)
-	if err = json.Unmarshal(jsonQueryParams, &queryParams); err != nil {
-		return nil, &Error{Err: err}
-	}
-
 	clientRequest := &ClientRequest{
-		Path:        "payments",
-		QueryParams: queryParams,
-		Result:      &PaymentResult{},
+		Path:      "payments",
+		UrlValues: urlValues,
+		Result:    &PaymentResult{},
 	}
 
 	result, clientErr := ir.client.Get(ctx, clientRequest)

--- a/payment_test.go
+++ b/payment_test.go
@@ -1,0 +1,95 @@
+package lago_test
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	. "github.com/getlago/lago-go-client"
+)
+
+func TestPaymentListFilters(t *testing.T) {
+	for _, customerScoped := range []bool{false, true} {
+		name := "payments"
+		if customerScoped {
+			name = "customer payments"
+		}
+		t.Run(name, func(t *testing.T) {
+			c := qt.New(t)
+			page, perPage := 2, 5
+			var from int64 = 0
+			var to int64 = math.MaxInt64
+			want := url.Values{
+				"page": {"2"}, "per_page": {"5"}, "invoice_id": {"1a901a90-1a90-1a90-1a90-1a901a901a90"},
+				"payment_status[]": {"succeeded", "failed"}, "payment_statuses[]": {"pending"},
+				"amount_from": {"0"}, "amount_to": {"9223372036854775807"}, "receipt_number": {"Rcpt & +/#1"},
+				"created_at_from": {"2026-09-01"}, "created_at_to": {"2026-09-07"},
+				"payment_provider_type[]": {"stripe", "gocardless"}, "payment_method_type[]": {"card", "sepa_debit"},
+				"currency": {"EUR"}, "invoice_number": {"LAG & +/#2"}, "payment_type[]": {"manual", "provider"},
+				"payable_type[]": {"Invoice", "PaymentRequest"}, "search_term": {"pi_3 & +/#"},
+			}
+			path := "/api/v1/payments"
+			if customerScoped {
+				path = "/api/v1/customers/cust_1/payments"
+			} else {
+				want.Set("external_customer_id", "cust_1")
+			}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				c.Check(r.Method, qt.Equals, http.MethodGet)
+				c.Check(r.URL.Path, qt.Equals, path)
+				c.Check(r.URL.Query(), qt.DeepEquals, want)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"payments":[],"meta":{"current_page":2,"total_count":7}}`))
+			}))
+			defer server.Close()
+			client := New().SetBaseURL(server.URL).SetApiKey("test_api_key")
+			var result *PaymentResult
+			var err *Error
+			if customerScoped {
+				result, err = client.Customer().GetPaymentList(context.Background(), "cust_1", &CustomerPaymentListInput{
+					Page: &page, PerPage: &perPage, InvoiceID: want.Get("invoice_id"), PaymentStatus: want["payment_status[]"], PaymentStatuses: want["payment_statuses[]"],
+					AmountFrom: &from, AmountTo: &to, ReceiptNumber: want.Get("receipt_number"), CreatedAtFrom: want.Get("created_at_from"), CreatedAtTo: want.Get("created_at_to"),
+					PaymentProviderType: want["payment_provider_type[]"], PaymentMethodType: want["payment_method_type[]"], Currency: Currency("EUR"), InvoiceNumber: want.Get("invoice_number"),
+					PaymentType: want["payment_type[]"], PayableType: want["payable_type[]"], SearchTerm: want.Get("search_term"),
+				})
+			} else {
+				result, err = client.Payment().GetList(context.Background(), &PaymentListInput{
+					Page: &page, PerPage: &perPage, ExternalCustomerID: "cust_1", InvoiceID: want.Get("invoice_id"), PaymentStatus: want["payment_status[]"], PaymentStatuses: want["payment_statuses[]"],
+					AmountFrom: &from, AmountTo: &to, ReceiptNumber: want.Get("receipt_number"), CreatedAtFrom: want.Get("created_at_from"), CreatedAtTo: want.Get("created_at_to"),
+					PaymentProviderType: want["payment_provider_type[]"], PaymentMethodType: want["payment_method_type[]"], Currency: Currency("EUR"), InvoiceNumber: want.Get("invoice_number"),
+					PaymentType: want["payment_type[]"], PayableType: want["payable_type[]"], SearchTerm: want.Get("search_term"),
+				})
+			}
+			c.Assert(err == nil, qt.IsTrue)
+			c.Check(result.Meta.TotalCount, qt.Equals, 7)
+		})
+	}
+}
+
+func TestPaymentListWithoutFilters(t *testing.T) {
+	c := qt.New(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.URL.RawQuery, qt.Equals, "")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"payments":[],"meta":{"total_count":0}}`))
+	}))
+	defer server.Close()
+	client := New().SetBaseURL(server.URL)
+	for _, input := range []*PaymentListInput{nil, {}} {
+		_, err := client.Payment().GetList(context.Background(), input)
+		c.Assert(err == nil, qt.IsTrue)
+	}
+}
+
+func TestPaymentListExistingJSONTags(t *testing.T) {
+	c := qt.New(t)
+	page := 2
+	data, err := json.Marshal(&PaymentListInput{Page: &page, ExternalCustomerID: "cust_1", InvoiceID: "inv"})
+	c.Assert(err == nil, qt.IsTrue)
+	c.Check(string(data), qt.JSONEquals, map[string]string{"page": "2", "external_customer_id": "cust_1", "invoice_id": "inv"})
+}

--- a/payment_test.go
+++ b/payment_test.go
@@ -29,8 +29,8 @@ func TestPaymentListFilters(t *testing.T) {
 				"payment_status[]": {"succeeded", "failed"}, "payment_statuses[]": {"pending"},
 				"amount_from": {"0"}, "amount_to": {"9223372036854775807"}, "receipt_number": {"Rcpt & +/#1"},
 				"created_at_from": {"2026-09-01"}, "created_at_to": {"2026-09-07"},
-				"payment_provider_type[]": {"stripe", "gocardless"}, "payment_method_type[]": {"card", "sepa_debit"},
-				"currency": {"EUR"}, "invoice_number": {"LAG & +/#2"}, "payment_type[]": {"manual", "provider"},
+				"payment_provider_type[]": {"stripe", "gocardless"}, "currency": {"EUR"},
+				"invoice_number": {"LAG & +/#2"}, "payment_type[]": {"manual", "provider"},
 				"payable_type[]": {"Invoice", "PaymentRequest"}, "search_term": {"pi_3 & +/#"},
 			}
 			path := "/api/v1/payments"
@@ -54,14 +54,14 @@ func TestPaymentListFilters(t *testing.T) {
 				result, err = client.Customer().GetPaymentList(context.Background(), "cust_1", &CustomerPaymentListInput{
 					Page: &page, PerPage: &perPage, InvoiceID: want.Get("invoice_id"), PaymentStatus: want["payment_status[]"], PaymentStatuses: want["payment_statuses[]"],
 					AmountFrom: &from, AmountTo: &to, ReceiptNumber: want.Get("receipt_number"), CreatedAtFrom: want.Get("created_at_from"), CreatedAtTo: want.Get("created_at_to"),
-					PaymentProviderType: want["payment_provider_type[]"], PaymentMethodType: want["payment_method_type[]"], Currency: Currency("EUR"), InvoiceNumber: want.Get("invoice_number"),
+					PaymentProviderType: want["payment_provider_type[]"], Currency: Currency("EUR"), InvoiceNumber: want.Get("invoice_number"),
 					PaymentType: want["payment_type[]"], PayableType: want["payable_type[]"], SearchTerm: want.Get("search_term"),
 				})
 			} else {
 				result, err = client.Payment().GetList(context.Background(), &PaymentListInput{
 					Page: &page, PerPage: &perPage, ExternalCustomerID: "cust_1", InvoiceID: want.Get("invoice_id"), PaymentStatus: want["payment_status[]"], PaymentStatuses: want["payment_statuses[]"],
 					AmountFrom: &from, AmountTo: &to, ReceiptNumber: want.Get("receipt_number"), CreatedAtFrom: want.Get("created_at_from"), CreatedAtTo: want.Get("created_at_to"),
-					PaymentProviderType: want["payment_provider_type[]"], PaymentMethodType: want["payment_method_type[]"], Currency: Currency("EUR"), InvoiceNumber: want.Get("invoice_number"),
+					PaymentProviderType: want["payment_provider_type[]"], Currency: Currency("EUR"), InvoiceNumber: want.Get("invoice_number"),
 					PaymentType: want["payment_type[]"], PayableType: want["payable_type[]"], SearchTerm: want.Get("search_term"),
 				})
 			}


### PR DESCRIPTION
Add typed payment list inputs and URL tags to both payment list routes, including optional *int64 bounds so zero and an omitted value stay distinct. The global list now uses the same query encoder as customer/invoice lists; existing JSON field names remain compatible.

Both top-level and customer-scoped payment lists accept status/status alias, inclusive int64 amount bounds, receipt number, created date bounds, provider, method, currency, invoice number, payment type, payable type and search. Existing pagination, customer ID and invoice ID options remain supported. Array values serialize as repeated bracketed keys; exact text is URL-encoded.

Source: lago-openapi `feat/payments-list-filters` at `1cb1dd67552d07279e74f005ac28d3e9684a76f7` (bundled SHA-256 `edc85fddf229feb79974e65bb8c7a1a8e720926cb294d3749e6bd572edb72d7d`).

Live QA: succeeded + EUR returns the same seven IDs as UI/REST; cust_1 returns two; amount_from=9223372036854775807 returns two. [API and client QA](https://github.com/getlago/lago-api/blob/feat/payments-list-filters/qa/payments-filters/README.md), [79 HTTP assertions](https://github.com/getlago/lago-api/blob/feat/payments-list-filters/qa/payments-filters/api-qa.json), [cross-client IDs](https://github.com/getlago/lago-api/blob/feat/payments-list-filters/qa/payments-filters/cross-client-qa.json), [UI QA and recording](https://github.com/getlago/lago-front/blob/feat/payments-list-filters/qa/payments-filters/README.md).


Verification: `go test ./...`, `go build ./...`, gofmt; httptest covers all parameters on both routes, arrays, punctuation, zero, nil, empty arrays and maximum int64. No changelog exists. No version bump or API response changes.

<!-- linked-prs -->
## Related PRs

- [lago-api](https://github.com/getlago/lago-api/pull/6325)
- [lago-front](https://github.com/getlago/lago-front/pull/4275)
- [lago-openapi](https://github.com/getlago/lago-openapi/pull/579)
- [lago-go-client](https://github.com/getlago/lago-go-client/pull/365)
- [lago-python-client](https://github.com/getlago/lago-python-client/pull/419)
- [lago-ruby-client](https://github.com/getlago/lago-ruby-client/pull/373)
- [lago-rust-client](https://github.com/getlago/lago-rust-client/pull/61)
- [lago-javascript-client](https://github.com/getlago/lago-javascript-client/pull/99)
- [lago-php-client](https://github.com/getlago/lago-php-client/pull/5)
- [lago-cli](https://github.com/getlago/lago-cli/pull/27)

Merge order: API, then front; OpenAPI before client/CLI releases. JavaScript CI uses the pinned feature spec during that rollout.

## Performance follow-up (2026-09-09)

`payment_method_type` removed from the payments list filters: the Lago API dropped it for performance reasons (getlago/lago-api#6325, "Not shipped for performance reasons"). This client no longer sends or documents it; every other filter is unchanged. Indexes for the remaining filters ship first in getlago/lago-api#6341.